### PR TITLE
Fix a trivial typo in the tutorial.

### DIFF
--- a/doc/html/boost_bimap/the_tutorial/discovering_the_bimap_framework.html
+++ b/doc/html/boost_bimap/the_tutorial/discovering_the_bimap_framework.html
@@ -222,7 +222,7 @@
 </tr>
 <tr><td align="left" valign="top">
 <p>
-            You have to used references to views, and not directly views object.
+            You have to use references to views, and not directly views object.
             Views cannot be constructed as separate objects from the container they
             belong to, so the following:
 </p>


### PR DESCRIPTION
`s/used/use/` just because I stumbled when reading this.