### PR TITLE
Fix example compile break

### DIFF
--- a/example/bimap_and_boost/property_map.cpp
+++ b/example/bimap_and_boost/property_map.cpp
@@ -39,7 +39,7 @@ void foo(AddressMap & address_map)
 
     value_type address;
     key_type fred = "Fred";
-    std::cout << get(address_map, fred);
+    std::cout << boost::get(address_map, fred);
 }
 
 int main()


### PR DESCRIPTION
After https://github.com/boostorg/utility/commit/08a1b7da61a6bb18932e115405e31d1b79a78100,
boost::get needs an explicit namespace qualification.