### PR TITLE
Update Test Suite, unordered_associative_container_adaptor, and structured_pair

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Copyright 2016, 2017 Peter Dimov
 # Distributed under the Boost Software License, Version 1.0.
-# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://boost.org/LICENSE_1_0.txt)
 
 language: cpp
 
@@ -24,53 +25,17 @@ matrix:
     - env: BOGUS_JOB=true
 
   include:
-    - os: linux
-      compiler: g++
-      env: TOOLSET=gcc CXXSTD=03,11
-
-    - os: linux
-      compiler: g++-5
-      env: TOOLSET=gcc-5 CXXSTD=03,11,14,1z
-      addons:
-        apt:
-          packages:
-            - g++-5
-          sources:
-            - ubuntu-toolchain-r-test
-
-    - os: linux
-      compiler: g++-6
-      env: TOOLSET=gcc-6 CXXSTD=03,11,14,1z
-      addons:
-        apt:
-          packages:
-            - g++-6
-          sources:
-            - ubuntu-toolchain-r-test
-
-    - os: linux
-      compiler: g++-7
-      env: TOOLSET=gcc-7 CXXSTD=03,11,14,17
-      addons:
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
-
-    - os: linux
-      compiler: clang++
-      env: TOOLSET=clang CXXSTD=03,11,14,1z
-      addons:
-        apt:
-          packages:
-            - libstdc++-4.9-dev
-          sources:
-            - ubuntu-toolchain-r-test
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      osx_image: xcode6.4
 
     - os: osx
-      compiler: clang++
-      env: TOOLSET=clang CXXSTD=03,11,14,1z
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      osx_image: xcode7.3
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      osx_image: xcode8.3
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
@@ -79,6 +44,14 @@ install:
   - cd boost-root
   - git submodule update --init tools/build
   - git submodule update --init libs/config
+  - git submodule update --init libs/preprocessor
+  - git submodule update --init libs/typeof
+  - git submodule update --init libs/detail
+  - git submodule update --init libs/type_traits
+  - git submodule update --init libs/mpl
+  - git submodule update --init libs/core
+  - git submodule update --init libs/utility
+  - git submodule update --init libs/multi_index
   - git submodule update --init tools/boostdep
   - cp -r $TRAVIS_BUILD_DIR/* libs/bimap
   - python tools/boostdep/depinst/depinst.py bimap
@@ -86,7 +59,14 @@ install:
   - ./b2 headers
 
 script:
-  - ./b2 -j 3 libs/bimap/test toolset=$TOOLSET cxxstd=$CXXSTD
+  - |-
+    echo "using $TOOLSET : : $COMPILER ;" > ~/user-config.jam
+  - IFS=','
+  - for CXXLOCAL in $CXXSTD; do  (cd libs/config/test && ../../../b2 config_info_travis_install toolset=$TOOLSET cxxstd=$CXXLOCAL $CXXSTD_DIALECT && echo With Standard Version $CXXLOCAL && ./config_info_travis && rm ./config_info_travis)  done
+  - unset IFS
+  - cd libs/bimap/test
+  - ./b2 -j3 $TEST_SUITE toolset=$TOOLSET cxxstd=$CXXSTD $CXXSTD_DIALECT
+  - cd ../../..
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,174 @@ matrix:
     - env: BOGUS_JOB=true
 
   include:
+    - os: linux
+      compiler: g++-4.4
+      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=98,0x TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.4
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: g++-4.6
+      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03,0x TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.7 CXXSTD=03,11 TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.8 CXXSTD=03,11 TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.9 CXXSTD=03,11 TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=03,11,14 TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-5
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=03,11,14,1z CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03,11,14,17 TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03,11,14,17 CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.5 CXXSTD=03,11 TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.5
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.6 CXXSTD=03,11 TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.6
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.7 CXXSTD=03,11 TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.7
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.8
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.9 CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.9
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
+
+    - os: linux
+      compiler: clang++-4.0
+      env: TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+
+    - os: linux
+      compiler: clang++-5.0
+      env: TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
       osx_image: xcode6.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,6 @@ install:
   - cd boost-root
   - git submodule update --init tools/build
   - git submodule update --init libs/config
-  - git submodule update --init libs/preprocessor
-  - git submodule update --init libs/typeof
-  - git submodule update --init libs/detail
-  - git submodule update --init libs/type_traits
-  - git submodule update --init libs/mpl
-  - git submodule update --init libs/core
-  - git submodule update --init libs/utility
-  - git submodule update --init libs/multi_index
   - git submodule update --init tools/boostdep
   - cp -r $TRAVIS_BUILD_DIR/* libs/bimap
   - python tools/boostdep/depinst/depinst.py bimap
@@ -65,7 +57,7 @@ script:
   - for CXXLOCAL in $CXXSTD; do  (cd libs/config/test && ../../../b2 config_info_travis_install toolset=$TOOLSET cxxstd=$CXXLOCAL $CXXSTD_DIALECT && echo With Standard Version $CXXLOCAL && ./config_info_travis && rm ./config_info_travis)  done
   - unset IFS
   - cd libs/bimap/test
-  - ./b2 -j3 $TEST_SUITE toolset=$TOOLSET cxxstd=$CXXSTD $CXXSTD_DIALECT
+  - ../../../b2 -j3 $TEST_SUITE toolset=$TOOLSET cxxstd=$CXXSTD $CXXSTD_DIALECT
   - cd ../../..
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
 
     - os: linux
       compiler: g++-4.6
-      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03,0x TEST_SUITE=bimap_all_tests
+      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03,0x TEST_SUITE=bimap_tests_no_xpressive
       addons:
         apt:
           packages:
@@ -152,7 +152,7 @@ matrix:
             - llvm-toolchain-precise-3.7
 
     - os: linux
-      env: TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      env: TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=03,11,14,1z TEST_SUITE=bimap_tests_no_serialization
       addons:
         apt:
           packages:
@@ -162,7 +162,7 @@ matrix:
             - llvm-toolchain-precise-3.8
 
     - os: linux
-      env: TOOLSET=clang COMPILER=clang++-3.9 CXXSTD=03,11,14,1z TEST_SUITE=bimap_all_tests
+      env: TOOLSET=clang COMPILER=clang++-3.9 CXXSTD=03,11,14,1z TEST_SUITE=bimap_tests_no_serialization
       addons:
         apt:
           packages:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,77 @@
+# Copyright 2018 Cromwell D. Enage
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://boost.org/LICENSE_1_0.txt)
+
+version: 1.0.{build}-{branch}
+
+shallow_clone: true
+
+branches:
+  only:
+    - master
+    - develop
+
+platform:
+  - x64
+
+environment:
+  matrix:
+    - ARGS: --toolset=gcc address-model=32
+      TEST_SUITE: bimap_all_tests
+      PATH: C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin;%PATH%
+    - ARGS: --toolset=gcc address-model=32 linkflags=-Wl,-allow-multiple-definition
+      TEST_SUITE: bimap_all_tests
+      PATH: C:\MinGW\bin;%PATH%
+    - ARGS: --toolset=gcc address-model=64
+      TEST_SUITE: bimap_all_tests
+      PATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
+    - ARGS: --toolset=gcc address-model=64 cxxflags=-std=gnu++1z
+      TEST_SUITE: bimap_all_tests
+      PATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
+    - ARGS: --toolset=msvc-9.0  address-model=32
+      TEST_SUITE: bimap_all_tests
+    - ARGS: --toolset=msvc-10.0 address-model=32
+      TEST_SUITE: bimap_all_tests
+    - ARGS: --toolset=msvc-11.0 address-model=32
+      TEST_SUITE: bimap_all_tests
+    - ARGS: --toolset=msvc-12.0 address-model=32
+      TEST_SUITE: bimap_all_tests
+    - ARGS: --toolset=msvc-14.0 address-model=32
+      TEST_SUITE: bimap_all_tests
+    - ARGS: --toolset=msvc-12.0 address-model=64
+      TEST_SUITE: bimap_all_tests
+    - ARGS: --toolset=msvc-14.0 address-model=64
+      TEST_SUITE: bimap_all_tests
+    - ARGS: --toolset=msvc-14.0 address-model=64 cxxflags=-std:c++latest
+      TEST_SUITE: bimap_all_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARGS: --toolset=msvc-14.1 address-model=32
+      TEST_SUITE: bimap_all_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARGS: --toolset=msvc-14.1 address-model=64
+      TEST_SUITE: bimap_all_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARGS: --toolset=msvc-14.1 address-model=64 cxxflags=-std:c++latest
+      TEST_SUITE: bimap_all_tests
+
+install:
+  - cd ..
+  - git clone -b %APPVEYOR_REPO_BRANCH% https://github.com/boostorg/boost.git boost-root
+  - cd boost-root
+  - git submodule update --init tools/build
+  - git submodule update --init libs/config
+  - git submodule update --init tools/boostdep
+  - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\bimap
+  - python tools/boostdep/depinst/depinst.py bimap
+  - bootstrap
+  - b2 headers
+
+build: off
+
+test_script:
+  - cd libs\config\test
+  - ..\..\..\b2 config_info_travis_install %ARGS%
+  - config_info_travis
+  - cd ..\..\bimap\test
+  - ..\..\..\b2 -j3 --hash %ARGS% %TEST_SUITE%

--- a/include/boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp
+++ b/include/boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp
@@ -184,6 +184,16 @@ class unordered_associative_container_adaptor :
 
     // bucket interface:
 
+    hasher hash_function() const
+    {
+        return this->base().hash_function();
+    }
+
+    key_equal key_eq() const
+    {
+        return this->base().key_eq();
+    }
+
     BOOST_DEDUCED_TYPENAME base_::size_type bucket_count() const
     {
         return this->base().bucket_count();
@@ -258,6 +268,11 @@ class unordered_associative_container_adaptor :
     void rehash(BOOST_DEDUCED_TYPENAME base_::size_type n)
     {
         return this->base().rehash(n);
+    }
+
+    void reserve(BOOST_DEDUCED_TYPENAME base_::size_type count)
+    {
+        return this->base().reserve(count);
     }
 
     // We have redefined end and begin so we have to manually route the old ones

--- a/include/boost/bimap/relation/structured_pair.hpp
+++ b/include/boost/bimap/relation/structured_pair.hpp
@@ -218,7 +218,7 @@ class pair_info_hook<TA,TB,::boost::mpl::na,Layout> :
 
     protected:
 
-    pair_info_hook() : base() {}
+    pair_info_hook() : base_() {}
 
     pair_info_hook( BOOST_DEDUCED_TYPENAME ::boost::call_traits<
                         BOOST_DEDUCED_TYPENAME base_::first_type

--- a/include/boost/bimap/relation/structured_pair.hpp
+++ b/include/boost/bimap/relation/structured_pair.hpp
@@ -372,16 +372,16 @@ template< class FirstType, class SecondType, class Info, class Layout1, class La
 bool operator<(const structured_pair<FirstType,SecondType,Info,Layout1> & a,
                const structured_pair<FirstType,SecondType,Info,Layout2> & b)
 {
-    return (  ( a.first  <  b.first  ) ||
-             (( a.first == b.first ) && ( a.second < b.second )));
+    return (  ( (a.first)  <  (b.first)  ) ||
+             (( (a.first) == (b.first) ) && ( (a.second) < (b.second) )));
 }
 
 template< class FirstType, class SecondType, class Info, class Layout1, class Layout2 >
 bool operator<=(const structured_pair<FirstType,SecondType,Info,Layout1> & a,
                 const structured_pair<FirstType,SecondType,Info,Layout2> & b)
 {
-    return (  ( a.first  <  b.first  ) ||
-             (( a.first == b.first ) && ( a.second <= b.second )));
+    return (  ( (a.first)  <  (b.first)  ) ||
+             (( (a.first) == (b.first) ) && ( (a.second) <= (b.second) )));
 }
 
 template< class FirstType, class SecondType, class Info, class Layout1, class Layout2 >
@@ -421,16 +421,16 @@ template< class FirstType, class SecondType, class Info, class Layout, class F, 
 bool operator<(const structured_pair<FirstType,SecondType,Info,Layout> & a,
                const std::pair<F,S> & b)
 {
-    return (  ( a.first  <  b.first  ) ||
-             (( a.first == b.first ) && ( a.second < b.second )));
+    return (  ( (a.first)  <  (b.first)  ) ||
+             (( (a.first) == (b.first) ) && ( (a.second) < (b.second) )));
 }
 
 template< class FirstType, class SecondType, class Info, class Layout, class F, class S >
 bool operator<=(const structured_pair<FirstType,SecondType,Info,Layout> & a,
                 const std::pair<F,S> & b)
 {
-    return (  ( a.first  <  b.first  ) ||
-             (( a.first == b.first ) && ( a.second <= b.second )));
+    return (  ( (a.first)  <  (b.first)  ) ||
+             (( (a.first) == (b.first) ) && ( (a.second) <= (b.second) )));
 }
 
 template< class FirstType, class SecondType, class Info, class Layout, class F, class S >
@@ -470,16 +470,16 @@ template< class FirstType, class SecondType, class Info, class Layout, class F, 
 bool operator<(const std::pair<F,S> & a,
                const structured_pair<FirstType,SecondType,Info,Layout> & b)
 {
-    return (  ( a.first  <  b.first  ) ||
-             (( a.first == b.first ) && ( a.second < b.second )));
+    return (  ( (a.first)  <  (b.first)  ) ||
+             (( (a.first) == (b.first) ) && ( (a.second) < (b.second) )));
 }
 
 template< class FirstType, class SecondType, class Info, class Layout, class F, class S >
 bool operator<=(const std::pair<F,S> & a,
                 const structured_pair<FirstType,SecondType,Info,Layout> & b)
 {
-    return (  ( a.first  <  b.first  ) ||
-             (( a.first == b.first ) && ( a.second <= b.second )));
+    return (  ( (a.first)  <  (b.first)  ) ||
+             (( (a.first) == (b.first) ) && ( (a.second) <= (b.second) )));
 }
 
 template< class FirstType, class SecondType, class Info, class Layout, class F, class S >

--- a/include/boost/bimap/relation/structured_pair.hpp
+++ b/include/boost/bimap/relation/structured_pair.hpp
@@ -26,7 +26,7 @@
 
 #include <boost/call_traits.hpp>
 
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/vector.hpp>
@@ -67,7 +67,7 @@ class normal_storage :
     first_type   first;
     second_type  second;
 
-    normal_storage() {}
+    normal_storage() : first(), second() {}
 
     normal_storage(BOOST_DEDUCED_TYPENAME ::boost::call_traits<
                         first_type >::param_type f,
@@ -104,7 +104,7 @@ class mirror_storage :
     second_type  second;
     first_type   first;
 
-    mirror_storage() {}
+    mirror_storage() : second(), first() {}
 
     mirror_storage(BOOST_DEDUCED_TYPENAME ::boost::call_traits<first_type  >::param_type f,
                    BOOST_DEDUCED_TYPENAME ::boost::call_traits<second_type >::param_type s)
@@ -174,7 +174,7 @@ class pair_info_hook :
 
     protected:
 
-    pair_info_hook() {}
+    pair_info_hook() : base_(), info() {}
 
     pair_info_hook( BOOST_DEDUCED_TYPENAME ::boost::call_traits<
                         BOOST_DEDUCED_TYPENAME base_::first_type
@@ -218,7 +218,7 @@ class pair_info_hook<TA,TB,::boost::mpl::na,Layout> :
 
     protected:
 
-    pair_info_hook() {}
+    pair_info_hook() : base() {}
 
     pair_info_hook( BOOST_DEDUCED_TYPENAME ::boost::call_traits<
                         BOOST_DEDUCED_TYPENAME base_::first_type
@@ -291,7 +291,7 @@ class structured_pair :
 
     > mutant_views;
 
-    structured_pair() {}
+    structured_pair() : base_() {}
 
     structured_pair(BOOST_DEDUCED_TYPENAME boost::call_traits<
                         BOOST_DEDUCED_TYPENAME base_::first_type  >::param_type f,

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -219,15 +219,15 @@ alias bimap_test
         :
             <preserve-target-tests>off
     ]
-#    [ run test_bimap_serialization.cpp
-#          /boost/serialization//boost_serialization
-#        :
-#        :
-#        :
-#        :
-#        :
-#            <preserve-target-tests>off
-#    ]
+    [ run test_bimap_serialization.cpp
+            /boost/serialization//boost_serialization
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
     [ run test_bimap_info.cpp
         :
         :
@@ -306,9 +306,9 @@ alias bimap_and_boost
         :
             <preserve-target-tests>off
     ]
-#    [ compile ../example/bimap_and_boost/serialization.cpp
-#        /boost/serialization//boost_serialization
-#    ]
+    [ compile ../example/bimap_and_boost/serialization.cpp
+            /boost/serialization//boost_serialization
+    ]
     ;
 
 alias bimap_all_tests

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -219,15 +219,6 @@ alias bimap_test
         :
             <preserve-target-tests>off
     ]
-    [ run test_bimap_serialization.cpp
-            /boost/serialization//boost_serialization
-        :
-        :
-        :
-        :
-        :
-            <preserve-target-tests>off
-    ]
     [ run test_bimap_info.cpp
         :
         :
@@ -290,6 +281,18 @@ alias bimap_and_boost
         :
             <preserve-target-tests>off
     ]
+    [ run ../example/bimap_and_boost/typeof.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    ;
+
+alias bimap_with_xpressive
+    :
     [ run ../example/bimap_and_boost/xpressive.cpp
         :
         :
@@ -298,7 +301,12 @@ alias bimap_and_boost
         :
             <preserve-target-tests>off
     ]
-    [ run ../example/bimap_and_boost/typeof.cpp
+    ;
+
+alias bimap_with_serialization
+    :
+    [ run test_bimap_serialization.cpp
+            /boost/serialization//boost_serialization
         :
         :
         :
@@ -311,11 +319,30 @@ alias bimap_and_boost
     ]
     ;
 
-alias bimap_all_tests
+alias bimap_minimal_tests
     :
         bimap_tagged_test
         bimap_relation_test
         bimap_test
         bimap_compile_fail_test
         bimap_and_boost
+    ;
+
+alias bimap_tests_no_xpressive
+    :
+        bimap_minimal_tests
+        bimap_with_serialization
+    ;
+
+alias bimap_tests_no_serialization
+    :
+        bimap_minimal_tests
+        bimap_with_xpressive
+    ;
+
+alias bimap_all_tests
+    :
+        bimap_minimal_tests
+        bimap_with_xpressive
+        bimap_with_serialization
     ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,72 +9,313 @@
 # bring in rules for testing
 import testing ;
 
-
-test-suite "tagged_test"
+project boost/bimap
     :
-    [ run test_tagged.cpp                                                     ]
+        default-build
+        <warnings>off
     ;
 
-
-test-suite "relation_test"
+alias bimap_tagged_test
     :
-    [ run test_structured_pair.cpp                                            ]
-    [ run test_mutant.cpp                                                     ]
-    [ run test_mutant_relation.cpp                                            ]
+    [ run test_tagged.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
     ;
 
-
-test-suite "bimap_test"
+alias bimap_relation_test
     :
+    [ run test_structured_pair.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_mutant.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_mutant_relation.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    ;
 
+alias bimap_test
+    :
     # Check library user interface
-    [ run test_bimap_set_of.cpp                                               ]
-    [ run test_bimap_multiset_of.cpp                                          ]
-    [ run test_bimap_unordered_set_of.cpp                                     ]
-    [ run test_bimap_unordered_multiset_of.cpp                                ]
-    [ run test_bimap_list_of.cpp                                              ]
-    [ run test_bimap_vector_of.cpp                                            ]
-
+    [ run test_bimap_set_of.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_multiset_of.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_unordered_set_of.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_unordered_multiset_of.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_list_of.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_vector_of.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
     # Test bimap container
-    [ run test_bimap_ordered.cpp                                              ]
-    [ run test_bimap_unordered.cpp                                            ]
-    [ run test_bimap_sequenced.cpp                                            ]
-    [ run test_bimap_unconstrained.cpp                                        ]
-    [ run test_bimap_assign.cpp                                               ]
-    [ run test_bimap_property_map.cpp                                         ]
-    [ run test_bimap_modify.cpp                                               ]
-    [ run test_bimap_range.cpp                                                ]
-    [ run test_bimap_operator_bracket.cpp                                     ]
-    [ run test_bimap_lambda.cpp                                               ]
-    [ run test_bimap_mutable.cpp                                              ]
-    [ run test_bimap_extra.cpp                                                ]
-    [ run test_bimap_convenience_header.cpp                                   ]
-    [ run test_bimap_project.cpp                                              ]
-    [ run test_bimap_serialization.cpp
-          /boost/serialization//boost_serialization                           ]
-    [ run test_bimap_info.cpp                                                 ]
+    [ run test_bimap_ordered.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_unordered.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_sequenced.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_unconstrained.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_assign.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_property_map.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_modify.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_range.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_operator_bracket.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_lambda.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_mutable.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_extra.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_convenience_header.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run test_bimap_project.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+#    [ run test_bimap_serialization.cpp
+#          /boost/serialization//boost_serialization
+#        :
+#        :
+#        :
+#        :
+#        :
+#            <preserve-target-tests>off
+#    ]
+    [ run test_bimap_info.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
     ;
 
-test-suite "compile_fail_test"
+alias bimap_compile_fail_test
     :
-
-    [ compile-fail compile_fail/test_bimap_mutable_1.cpp                      ]
-    [ compile-fail compile_fail/test_bimap_mutable_2.cpp                      ]
-    [ compile-fail compile_fail/test_bimap_mutable_3.cpp                      ]
-    [ compile-fail compile_fail/test_bimap_info_1.cpp                         ]
-    [ compile-fail compile_fail/test_bimap_info_2.cpp                         ]
-    [ compile-fail compile_fail/test_bimap_info_3.cpp                         ]
+    [ compile-fail compile_fail/test_bimap_mutable_1.cpp ]
+    [ compile-fail compile_fail/test_bimap_mutable_2.cpp ]
+    [ compile-fail compile_fail/test_bimap_mutable_3.cpp ]
+    [ compile-fail compile_fail/test_bimap_info_1.cpp ]
+    [ compile-fail compile_fail/test_bimap_info_2.cpp ]
+    [ compile-fail compile_fail/test_bimap_info_3.cpp ]
     ;
 
-test-suite "bimap_and_boost"
+alias bimap_and_boost
     :
-    [ run     ../example/bimap_and_boost/property_map.cpp                     ]
-    [ run     ../example/bimap_and_boost/range.cpp                            ]
-    [ run     ../example/bimap_and_boost/foreach.cpp                          ]
-    [ run     ../example/bimap_and_boost/lambda.cpp                           ]
-    [ run     ../example/bimap_and_boost/assign.cpp                           ]
-    [ run     ../example/bimap_and_boost/xpressive.cpp                        ]
-    [ run     ../example/bimap_and_boost/typeof.cpp                           ]
-    [ compile ../example/bimap_and_boost/serialization.cpp
-                    /boost/serialization//boost_serialization                 ]
+    [ run ../example/bimap_and_boost/property_map.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run ../example/bimap_and_boost/range.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run ../example/bimap_and_boost/foreach.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run ../example/bimap_and_boost/lambda.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run ../example/bimap_and_boost/assign.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run ../example/bimap_and_boost/xpressive.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run ../example/bimap_and_boost/typeof.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+#    [ compile ../example/bimap_and_boost/serialization.cpp
+#        /boost/serialization//boost_serialization
+#    ]
+    ;
+
+alias bimap_all_tests
+    :
+        bimap_tagged_test
+        bimap_relation_test
+        bimap_test
+        bimap_compile_fail_test
+        bimap_and_boost
     ;

--- a/test/compile_fail/test_bimap_info_1.cpp
+++ b/test/compile_fail/test_bimap_info_1.cpp
@@ -17,33 +17,31 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/list_of.hpp>
 
-
 void test_bimap_info_1()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< int, list_of<int>, with_info<int> > bm_type;
+    typedef bimap<int,list_of<int>,with_info<int> > bm_type;
     bm_type bm;
-    bm.insert( bm_type::value_type(1,1) );
+    bm.insert(bm_type::value_type(1, 1));
 
     // fail test
     {
-        const bm_type & cbm = bm;
+        bm_type const& cbm = bm;
         cbm.begin()->info = 10;
     }
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_info_1();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/compile_fail/test_bimap_info_2.cpp
+++ b/test/compile_fail/test_bimap_info_2.cpp
@@ -17,21 +17,20 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/list_of.hpp>
 
-
 void test_bimap_info_2()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< int, list_of<int> > bm_type;
+    typedef bimap<int,list_of<int> > bm_type;
     bm_type bm;
-    bm.insert( bm_type::value_type(1,1) );
+    bm.insert(bm_type::value_type(1, 1));
 
     // fail test
     {
@@ -39,10 +38,9 @@ void test_bimap_info_2()
     }
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_info_2();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/compile_fail/test_bimap_info_3.cpp
+++ b/test/compile_fail/test_bimap_info_3.cpp
@@ -17,21 +17,20 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/list_of.hpp>
 
-
 void test_bimap_info_3()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< int, list_of<int> > bm_type;
+    typedef bimap<int,list_of<int> > bm_type;
     bm_type bm;
-    bm.insert( bm_type::value_type(1,1) );
+    bm.insert(bm_type::value_type(1, 1));
 
     // fail test
     {
@@ -39,10 +38,9 @@ void test_bimap_info_3()
     }
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_info_3();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/compile_fail/test_bimap_mutable_1.cpp
+++ b/test/compile_fail/test_bimap_mutable_1.cpp
@@ -17,33 +17,31 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/list_of.hpp>
 
-
 void test_bimap_mutable_1()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< int, list_of<int> > bm_type;
+    typedef bimap<int,list_of<int> > bm_type;
     bm_type bm;
-    bm.insert( bm_type::value_type(1,1) );
+    bm.insert(bm_type::value_type(1, 1));
 
     // fail test
     {
-        const bm_type & cbm = bm;
+        bm_type const& cbm = bm;
         cbm.begin()->right = 10;
     }
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_mutable_1();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/compile_fail/test_bimap_mutable_2.cpp
+++ b/test/compile_fail/test_bimap_mutable_2.cpp
@@ -17,33 +17,31 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/list_of.hpp>
 
-
 void test_bimap_mutable_2()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< int, list_of<int> > bm_type;
+    typedef bimap<int,list_of<int> > bm_type;
     bm_type bm;
-    bm.insert( bm_type::value_type(1,1) );
+    bm.insert(bm_type::value_type(1, 1));
 
     // fail test
     {
-        const bm_type & cbm = bm;
+        bm_type const& cbm = bm;
         cbm.left.find(1)->second = 10;
     }
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_mutable_2();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/compile_fail/test_bimap_mutable_3.cpp
+++ b/test/compile_fail/test_bimap_mutable_3.cpp
@@ -17,21 +17,20 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/list_of.hpp>
 
-
 void test_bimap_mutable_3()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< int, list_of<int> > bm_type;
+    typedef bimap<int,list_of<int> > bm_type;
     bm_type bm;
-    bm.insert( bm_type::value_type(1,1) );
+    bm.insert(bm_type::value_type(1, 1));
 
     // fail test
     {
@@ -39,10 +38,9 @@ void test_bimap_mutable_3()
     }
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_mutable_3();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap.hpp
+++ b/test/test_bimap.hpp
@@ -14,512 +14,505 @@
 #endif
 
 #include <boost/config.hpp>
-
-// std
-#include <cassert>
-#include <algorithm>
-#include <iterator>
-
 #include <boost/lambda/lambda.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/utility.hpp>
 #include <boost/next_prior.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+#include <boost/assert.hpp>
+#include <algorithm>
 
-template< class Container, class Data >
-void test_container(Container & c, const Data & d)
+template <typename Container, typename Data>
+void test_container(Container& c, Data const& d)
 {
-    assert( d.size() > 2 );
+    BOOST_ASSERT(d.size() > 2);
 
     c.clear();
+    BOOST_TEST(c.size() == 0);
+    BOOST_TEST(c.empty());
 
-    BOOST_CHECK( c.size() == 0 );
-    BOOST_CHECK( c.empty() );
+    c.insert(*d.begin());
+    c.insert(++d.begin(), d.end());
 
-    c.insert( *d.begin() );
+    BOOST_TEST(c.size() == d.size());
+    BOOST_TEST(c.size() <= c.max_size());
+    BOOST_TEST(!c.empty());
 
-    c.insert( ++d.begin(),d.end() );
+    c.erase(c.begin());
+    BOOST_TEST(c.size() == d.size() - 1);
 
-    BOOST_CHECK( c.size() == d.size() );
+    c.erase(c.begin(), c.end());
+    BOOST_TEST(c.empty());
 
-    BOOST_CHECK( c.size() <= c.max_size() );
-    BOOST_CHECK( ! c.empty() );
+    c.insert(*d.begin());
+    BOOST_TEST(c.size() == 1);
 
-    c.erase( c.begin() );
-
-    BOOST_CHECK( c.size() == d.size() - 1 );
-
-    c.erase( c.begin(), c.end() );
-
-    BOOST_CHECK( c.empty() );
-
-    c.insert( *d.begin() );
-
-    BOOST_CHECK( c.size() == 1 );
-
-    c.insert( c.begin(), *(++d.begin()) );
-
-    BOOST_CHECK( c.size() == 2 );
-
-    BOOST_CHECK( c.begin() != c.end() );
+    c.insert(c.begin(), *(++d.begin()));
+    BOOST_TEST(c.size() == 2);
+    BOOST_TEST(c.begin() != c.end());
 }
 
-template< class Container, class Data >
-void test_sequence_container(Container & c, const Data & d)
+template <typename Container, typename Data>
+void test_sequence_container(Container& c, Data const& d)
 {
-    assert( d.size() > 2 );
+    BOOST_ASSERT(d.size() > 2);
 
     c.clear();
+    BOOST_TEST(c.size() == 0);
+    BOOST_TEST(c.empty());
 
-    BOOST_CHECK( c.size() == 0 );
-    BOOST_CHECK( c.empty() );
+    c.push_front(*d.begin());
+    c.push_back(*(++d.begin()));
+    BOOST_TEST(c.front() == *c.begin());
+    BOOST_TEST(c.back() == *(++c.begin()));
+    BOOST_TEST(c.size() == 2);
+    BOOST_TEST(c.size() <= c.max_size());
+    BOOST_TEST(!c.empty());
 
-    c.push_front( *   d.begin()  );
-    c.push_back ( *(++d.begin()) );
+    c.erase(c.begin());
+    BOOST_TEST(c.size() == 1);
 
-    BOOST_CHECK( c.front() == *   c.begin()  );
-    BOOST_CHECK( c.back () == *(++c.begin()) );
+    c.insert(c.begin(), *(++d.begin()));
+    c.erase(c.begin(), c.end());
+    BOOST_TEST(c.empty());
 
-    BOOST_CHECK( c.size() == 2 );
-
-    BOOST_CHECK( c.size() <= c.max_size() );
-    BOOST_CHECK( ! c.empty() );
-
-    c.erase( c.begin() );
-
-    BOOST_CHECK( c.size() == 1 );
-
-    c.insert( c.begin(), *(++d.begin()) );
-
-    c.erase( c.begin(), c.end() );
-
-    BOOST_CHECK( c.empty() );
-
-    c.push_front( *d.begin() );
-
-    BOOST_CHECK( c.size() == 1 );
-
-    BOOST_CHECK( c.begin() != c.end() );
+    c.push_front(*d.begin());
+    BOOST_TEST(c.size() == 1);
+    BOOST_TEST(c.begin() != c.end());
 
     c.clear();
-    BOOST_CHECK( c.empty() );
+    BOOST_TEST(c.empty());
 
     // assign
-    
-    c.assign(d.begin(),d.end());
-    BOOST_CHECK( c.size() == d.size() );
-    BOOST_CHECK( std::equal( c.begin(), c.end(), d.begin() ) );
 
-    c.assign(d.size(),*d.begin());
-    BOOST_CHECK( c.size() == d.size() );
-    BOOST_CHECK( *c.begin() == *d.begin() );
-    
-    // Check insert(IterPos,InputIter,InputIter)
-    
+    c.assign(d.begin(), d.end());
+    BOOST_TEST(c.size() == d.size());
+    BOOST_TEST(std::equal(c.begin(), c.end(), d.begin()));
+
+    c.assign(d.size(), *d.begin());
+    BOOST_TEST(c.size() == d.size());
+    BOOST_TEST(*c.begin() == *d.begin());
+
+    // Check insert(IterPos, InputIter, InputIter)
+
     c.clear();
-    c.insert( c.begin(), d.begin(), d.end() );
-    c.insert( boost::next(c.begin(),2), d.begin(), d.end() );
-                   
-    BOOST_CHECK( std::equal( boost::next(c.begin(),2)
-                           , boost::next(c.begin(),2+d.size()) , d.begin() ) );
+    c.insert(c.begin(), d.begin(), d.end());
+    c.insert(boost::next(c.begin(), 2), d.begin(), d.end());
+
+    BOOST_TEST(
+       std::equal(
+           boost::next(c.begin(), 2)
+         , boost::next(c.begin(), 2 + d.size())
+         , d.begin()
+       )
+    );
 
     // Check resize
-   
-    c.clear() ;
-    c.resize(4,*d.begin());
-    BOOST_CHECK( c.size() == 4 );
-    BOOST_CHECK( *c.begin() == *d.begin() ) ;
-
-    BOOST_CHECK(     c == c   );
-    BOOST_CHECK( ! ( c != c ) );
-    BOOST_CHECK( ! ( c  < c ) );
-    BOOST_CHECK(   ( c <= c ) );
-    BOOST_CHECK( ! ( c  > c ) );
-    BOOST_CHECK(   ( c >= c ) );
-}
-
-template< class Container, class Data >
-void test_vector_container(Container & c, const Data & d)
-{
-    assert( d.size() > 2 );
-
-    c.clear() ;
-    c.reserve(2) ;
-    BOOST_CHECK( c.capacity() >= 2 ) ;
-    c.assign(d.begin(),d.end());
-    BOOST_CHECK( c.capacity() >= c.size() ) ;
-    
-    BOOST_CHECK( c[0] == *d.begin() ) ;
-    BOOST_CHECK( c.at(1) == *boost::next(d.begin()) );
-    
-    test_sequence_container(c,d) ;
-}
-
-template< class Container, class Data >
-void test_associative_container(Container & c, const Data & d)
-{
-    assert( d.size() > 2 );
 
     c.clear();
-    c.insert(d.begin(),d.end());
+    c.resize(4, *d.begin());
+    BOOST_TEST(c.size() == 4);
+    BOOST_TEST(*c.begin() == *d.begin());
+    BOOST_TEST(c == c);
+    BOOST_TEST(!(c != c));
+    BOOST_TEST(!(c < c));
+    BOOST_TEST((c <= c));
+    BOOST_TEST(!(c > c));
+    BOOST_TEST((c >= c));
+}
 
-    for( typename Data::const_iterator di = d.begin(), de = d.end();
-         di != de; ++di )
+template <typename Container, typename Data>
+void test_vector_container(Container& c, Data const& d)
+{
+    BOOST_ASSERT(d.size() > 2);
+
+    c.clear();
+    c.reserve(2);
+    BOOST_TEST(c.capacity() >= 2);
+
+    c.assign(d.begin(), d.end());
+    BOOST_TEST(c.capacity() >= c.size());
+    BOOST_TEST(c[0] == *d.begin());
+    BOOST_TEST(c.at(1) == *boost::next(d.begin()));
+    
+    test_sequence_container(c, d);
+}
+
+template <typename Container, typename Data>
+void test_associative_container(Container& c, Data const& d)
+{
+    BOOST_ASSERT(d.size() > 2);
+
+    c.clear();
+    c.insert(d.begin(), d.end());
+
+    for (
+        BOOST_DEDUCED_TYPENAME Data::const_iterator di = d.begin(
+        ), de = d.end();
+        di != de;
+        ++di
+    )
     {
-        BOOST_CHECK( c.find(*di) != c.end() );
+        BOOST_TEST(c.find(*di) != c.end());
     }
 
-    typename Data::const_iterator da =   d.begin();
-    typename Data::const_iterator db = ++d.begin();
+    BOOST_DEDUCED_TYPENAME Data::const_iterator da = d.begin();
+    BOOST_DEDUCED_TYPENAME Data::const_iterator db = ++d.begin();
 
     c.erase(*da);
-
-    BOOST_CHECK( c.size() == d.size()-1 );
-
-    BOOST_CHECK( c.count(*da) == 0 );
-    BOOST_CHECK( c.count(*db) == 1 );
-
-    BOOST_CHECK( c.find(*da) == c.end() );
-    BOOST_CHECK( c.find(*db) != c.end() );
-
-    BOOST_CHECK( c.equal_range(*db).first != c.end() );
+    BOOST_TEST(c.size() == d.size() - 1);
+    BOOST_TEST(c.count(*da) == 0);
+    BOOST_TEST(c.count(*db) == 1);
+    BOOST_TEST(c.find(*da) == c.end());
+    BOOST_TEST(c.find(*db) != c.end());
+    BOOST_TEST(c.equal_range(*db).first != c.end());
 
     c.clear();
-
-    BOOST_CHECK( c.equal_range(*da).first == c.end() );
+    BOOST_TEST(c.equal_range(*da).first == c.end());
 }
 
-
-template< class Container >
-void test_mapped_container(Container &)
+template <typename Container>
+void test_mapped_container(Container&)
 {
-    typedef BOOST_DEDUCED_TYPENAME Container:: value_type  value_type ;
-    typedef BOOST_DEDUCED_TYPENAME Container::   key_type    key_type ;
-    typedef BOOST_DEDUCED_TYPENAME Container::  data_type   data_type ;
-    typedef BOOST_DEDUCED_TYPENAME Container::mapped_type mapped_type ;
-
-    typedef BOOST_DEDUCED_TYPENAME 
-        boost::is_same< key_type
-                      , BOOST_DEDUCED_TYPENAME value_type::first_type
-                      >::type test_key_type;
-    BOOST_STATIC_ASSERT(test_key_type::value);
-
-    typedef BOOST_DEDUCED_TYPENAME
-        boost::is_same< data_type
-                      , BOOST_DEDUCED_TYPENAME value_type::second_type
-                      >::type test_data_type;
-    BOOST_STATIC_ASSERT(test_data_type::value);
-
-    typedef BOOST_DEDUCED_TYPENAME
-        boost::is_same< mapped_type
-                      , BOOST_DEDUCED_TYPENAME value_type::second_type
-                      >::type test_mapped_type;
-    BOOST_STATIC_ASSERT(test_mapped_type::value);
+    BOOST_TEST_TRAIT_TRUE((
+        boost::is_same<
+            BOOST_DEDUCED_TYPENAME Container::key_type
+          , BOOST_DEDUCED_TYPENAME Container::value_type::first_type
+        >
+    ));
+    BOOST_TEST_TRAIT_TRUE((
+        boost::is_same<
+            BOOST_DEDUCED_TYPENAME Container::data_type
+          , BOOST_DEDUCED_TYPENAME Container::value_type::second_type
+        >
+    ));
+    BOOST_TEST_TRAIT_TRUE((
+        boost::is_same<
+            BOOST_DEDUCED_TYPENAME Container::mapped_type
+          , BOOST_DEDUCED_TYPENAME Container::value_type::second_type
+        >
+    ));
 }
 
-template< class Container, class Data >
-void test_pair_associative_container(Container & c, const Data & d)
+template <typename Container, typename Data>
+void test_pair_associative_container(Container& c, Data const& d)
 {
     test_mapped_container(c);
 
-    assert( d.size() > 2 );
+    BOOST_ASSERT(d.size() > 2);
 
     c.clear();
-    c.insert(d.begin(),d.end());
+    c.insert(d.begin(), d.end());
 
-    for( typename Data::const_iterator di = d.begin(), de = d.end();
-         di != de; ++di )
+    for (
+        BOOST_DEDUCED_TYPENAME Data::const_iterator di = d.begin(
+        ), de = d.end();
+        di != de;
+        ++di
+    )
     {
-        BOOST_CHECK( c.find(di->first) != c.end() );
+        BOOST_TEST(c.find(di->first) != c.end());
     }
 
-    typename Data::const_iterator da =   d.begin();
-    typename Data::const_iterator db = ++d.begin();
+    BOOST_DEDUCED_TYPENAME Data::const_iterator da = d.begin();
+    BOOST_DEDUCED_TYPENAME Data::const_iterator db = ++d.begin();
 
     c.erase(da->first);
-
-    BOOST_CHECK( c.size() == d.size()-1 );
-
-    BOOST_CHECK( c.count(da->first) == 0 );
-    BOOST_CHECK( c.count(db->first) == 1 );
-
-    BOOST_CHECK( c.find(da->first) == c.end() );
-    BOOST_CHECK( c.find(db->first) != c.end() );
-
-    BOOST_CHECK( c.equal_range(db->first).first != c.end() );
+    BOOST_TEST(c.size() == d.size() - 1);
+    BOOST_TEST(c.count(da->first) == 0);
+    BOOST_TEST(c.count(db->first) == 1);
+    BOOST_TEST(c.find(da->first) == c.end());
+    BOOST_TEST(c.find(db->first) != c.end());
+    BOOST_TEST(c.equal_range(db->first).first != c.end());
 
     c.clear();
-
-    BOOST_CHECK( c.equal_range(da->first).first == c.end() );
+    BOOST_TEST(c.equal_range(da->first).first == c.end());
 }
 
-
-template< class Container, class Data >
-void test_simple_ordered_associative_container_equality(Container & c, const Data & d)
+template <typename Container, typename Data>
+void
+    test_simple_ordered_associative_container_equality(
+        Container& c
+      , Data const& d
+    )
 {
-    BOOST_CHECK( std::equal( c. begin(), c. end(), d. begin() ) );
-    BOOST_CHECK( std::equal( c.rbegin(), c.rend(), d.rbegin() ) );
-
-    BOOST_CHECK( c.lower_bound( *d.begin() ) ==   c.begin() );
-    BOOST_CHECK( c.upper_bound( *d.begin() ) == ++c.begin() );
+    BOOST_TEST(std::equal(c.begin(), c.end(), d.begin()));
+    BOOST_TEST(std::equal(c.rbegin(), c.rend(), d.rbegin()));
+    BOOST_TEST(c.lower_bound(*d.begin()) == c.begin());
+    BOOST_TEST(c.upper_bound(*d.begin()) == ++c.begin());
 }
 
-template< class Container, class Data >
-void test_simple_ordered_associative_container(Container & c, const Data & d)
+template <typename Container, typename Data>
+void test_simple_ordered_associative_container(Container& c, Data const& d)
 {
-    assert( d.size() > 2 );
+    BOOST_ASSERT(d.size() > 2);
 
     c.clear();
-    c.insert(d.begin(),d.end());
+    c.insert(d.begin(), d.end());
 
-    for( typename Data::const_iterator di = d.begin(), de = d.end();
-         di != de; ++di )
+    for (
+        BOOST_DEDUCED_TYPENAME Data::const_iterator di = d.begin(
+        ), de = d.end();
+        di != de;
+        ++di
+    )
     {
-        typename Container::const_iterator ci = c.find(*di);
-        BOOST_CHECK( ci != c.end() );
-
-        BOOST_CHECK( ! c.key_comp()(*ci,*di) );
-        BOOST_CHECK( ! c.value_comp()(*ci,*di) );
+        BOOST_DEDUCED_TYPENAME Container::const_iterator ci = c.find(*di);
+        BOOST_TEST(ci != c.end());
+        BOOST_TEST(!c.key_comp()(*ci, *di));
+        BOOST_TEST(!c.value_comp()(*ci, *di));
     }
 
     test_simple_ordered_associative_container_equality(c, d);
 
-    const Container & cr = c;
+    Container const& cr = c;
 
     test_simple_ordered_associative_container_equality(cr, d);
 
-    BOOST_CHECK(     c == c   );
-    BOOST_CHECK( ! ( c != c ) );
-    BOOST_CHECK( ! ( c  < c ) );
-    BOOST_CHECK(   ( c <= c ) );
-    BOOST_CHECK( ! ( c  > c ) );
-    BOOST_CHECK(   ( c >= c ) );
-    
-    /*
-    BOOST_CHECK( c.range( *c.begin() <= ::boost::lambda::_1,
-                            ::boost::lambda::_1 <= *(++c.begin()) ).
-                    first == c.begin()
+    BOOST_TEST(c == c);
+    BOOST_TEST(!(c != c));
+    BOOST_TEST(!(c < c));
+    BOOST_TEST((c <= c));
+    BOOST_TEST(!(c > c));
+    BOOST_TEST((c >= c));
+#if 0
+    BOOST_TEST(
+        c.range(
+            *c.begin() <= ::boost::lambda::_1
+          , ::boost::lambda::_1 <= *(++c.begin())
+        ).first == c.begin()
     );
-    */
+#endif
 }
 
-template< class Container, class Data >
-void test_simple_unordered_associative_container(Container & c, const Data & d)
+template <typename Container, typename Data>
+void test_simple_unordered_associative_container(Container& c, Data const& d)
 {
     c.clear();
-    c.insert( d.begin(), d.end() );
+    c.insert(d.begin(), d.end());
+    BOOST_TEST(c.bucket_count() * c.max_load_factor() >= d.size());
+    BOOST_TEST(c.max_bucket_count() >= c.bucket_count());
 
-    BOOST_CHECK( c.bucket_count() * c.max_load_factor() >= d.size() );
-    BOOST_CHECK( c.max_bucket_count() >= c.bucket_count() );
-
-    for( typename Data::const_iterator di = d.begin(), de = d.end() ;
-         di != de ; ++di )
+    for (
+        BOOST_DEDUCED_TYPENAME Data::const_iterator di = d.begin(
+        ), de = d.end();
+        di != de;
+        ++di
+    )
     {
         // non const
         {
-            typename Container::size_type nb = c.bucket(*c.find(*di));
-
-            BOOST_CHECK( c.begin(nb) != c.end(nb) );
+            BOOST_DEDUCED_TYPENAME Container::size_type nb = c.bucket(
+                *c.find(*di)
+            );
+            BOOST_TEST(c.begin(nb) != c.end(nb));
         }
 
         // const
         {
-            const Container & const_c = c;
+            Container const& const_c = c;
+            BOOST_TEST(const_c.bucket_size(const_c.bucket(*di)) == 1);
 
-            BOOST_CHECK(
-                const_c.bucket_size(const_c.bucket(*di)) == 1
+            BOOST_DEDUCED_TYPENAME Container::size_type nb = const_c.bucket(
+                *const_c.find(*di)
             );
-
-            typename Container::size_type nb =
-                const_c.bucket(*const_c.find(*di));
-
-            BOOST_CHECK(
-                const_c.begin(nb) != const_c.end(nb) 
-            );
+            BOOST_TEST(const_c.begin(nb) != const_c.end(nb));
         }
     }
 
-
-    BOOST_CHECK( c.load_factor() < c.max_load_factor() );
-
+    BOOST_TEST(c.load_factor() < c.max_load_factor());
     c.max_load_factor(0.75);
-
-    BOOST_CHECK( c.max_load_factor() == 0.75 );
-
+    BOOST_TEST(c.max_load_factor() == 0.75);
     c.rehash(10);
 }
 
-
-template< class Container, class Data >
-void test_pair_ordered_associative_container_equality(Container & c, const Data & d)
+template <typename Container, typename Data>
+void
+    test_pair_ordered_associative_container_equality(
+        Container& c
+      , Data const& d
+    )
 {
-    BOOST_CHECK( std::equal( c. begin(), c. end(), d. begin() ) );
-    BOOST_CHECK( std::equal( c.rbegin(), c.rend(), d.rbegin() ) );
-
-    BOOST_CHECK( c.lower_bound( d.begin()->first ) ==   c.begin() );
-    BOOST_CHECK( c.upper_bound( d.begin()->first ) == ++c.begin() );
+    BOOST_TEST(std::equal(c.begin(), c. end(), d.begin()));
+    BOOST_TEST(std::equal(c.rbegin(), c.rend(), d.rbegin()));
+    BOOST_TEST(c.lower_bound(d.begin()->first) == c.begin());
+    BOOST_TEST(c.upper_bound(d.begin()->first) == ++c.begin());
 }
 
-template< class Container, class Data >
-void test_pair_ordered_associative_container(Container & c, const Data & d)
+template <typename Container, typename Data>
+void test_pair_ordered_associative_container(Container& c, Data const& d)
 {
-    assert( d.size() > 2 );
+    BOOST_ASSERT(d.size() > 2);
 
     c.clear();
-    c.insert(d.begin(),d.end());
+    c.insert(d.begin(), d.end());
 
-    for( typename Container::const_iterator ci = c.begin(), ce = c.end();
-         ci != ce; ++ci )
+    for (
+        BOOST_DEDUCED_TYPENAME Container::const_iterator ci = c.begin(
+        ), ce = c.end();
+        ci != ce;
+        ++ci
+    )
     {
-        typename Data::const_iterator di = d.find(ci->first);
-        BOOST_CHECK( di != d.end() );
-        BOOST_CHECK( ! c.key_comp()(di->first,ci->first) );
-        BOOST_CHECK( ! c.value_comp()(*ci,*di) );
+        BOOST_DEDUCED_TYPENAME Data::const_iterator di = d.find(ci->first);
+        BOOST_TEST(di != d.end());
+        BOOST_TEST(!c.key_comp()(di->first, ci->first));
+        BOOST_TEST(!c.value_comp()(*ci, *di));
     }
 
     test_pair_ordered_associative_container_equality(c, d);
 
-    const Container & cr = c;
+    Container const& cr = c;
 
     test_pair_ordered_associative_container_equality(cr, d);
 
-    BOOST_CHECK( c.range( c.begin()->first <= ::boost::lambda::_1,
-                          ::boost::lambda::_1 <= (++c.begin())->first ).
-                    first == c.begin()
+    BOOST_TEST(
+        c.range(
+            c.begin()->first <= ::boost::lambda::_1
+          , ::boost::lambda::_1 <= (++c.begin())->first
+        ).first == c.begin()
     );
 }
 
-
-template< class Container, class Data >
-void test_pair_unordered_associative_container(Container & c, const Data & d)
+template <typename Container, typename Data>
+void test_pair_unordered_associative_container(Container& c, Data const& d)
 {
     c.clear();
-    c.insert( d.begin(), d.end() );
+    c.insert(d.begin(), d.end());
+    BOOST_TEST(c.bucket_count() * c.max_load_factor() >= d.size());
+    BOOST_TEST(c.max_bucket_count() >= c.bucket_count());
 
-    BOOST_CHECK( c.bucket_count() * c.max_load_factor() >= d.size() );
-    BOOST_CHECK( c.max_bucket_count() >= c.bucket_count() );
-
-    for( typename Data::const_iterator di = d.begin(), de = d.end() ;
-         di != de ; ++di )
+    for (
+        BOOST_DEDUCED_TYPENAME Data::const_iterator di = d.begin(
+        ), de = d.end();
+        di != de;
+        ++di
+    )
     {
         // non const
         {
-            typename Container::size_type nb =
-                c.bucket(c.find(di->first)->first);
-
-            BOOST_CHECK( c.begin(nb) != c.end(nb) );
+            BOOST_DEDUCED_TYPENAME Container::size_type nb = c.bucket(
+                c.find(di->first)->first
+            );
+            BOOST_TEST(c.begin(nb) != c.end(nb));
         }
 
         // const
         {
-            const Container & const_c = c;
+            Container const& const_c = c;
+            BOOST_TEST(const_c.bucket_size(const_c.bucket(di->first)) == 1);
 
-            BOOST_CHECK( const_c.bucket_size(const_c.bucket(di->first)) == 1 );
-
-            typename Container::size_type nb =
-                const_c.bucket(const_c.find(di->first)->first);
-
-            BOOST_CHECK( const_c.begin(nb) != const_c.end(nb) );
+            BOOST_DEDUCED_TYPENAME Container::size_type nb = const_c.bucket(
+                const_c.find(di->first)->first
+            );
+            BOOST_TEST(const_c.begin(nb) != const_c.end(nb));
         }
     }
 
-
-    BOOST_CHECK( c.load_factor() < c.max_load_factor() );
-
+    BOOST_TEST(c.load_factor() < c.max_load_factor());
     c.max_load_factor(0.75);
-
-    BOOST_CHECK( c.max_load_factor() == 0.75 );
-
+    BOOST_TEST(c.max_load_factor() == 0.75);
     c.rehash(10);
 }
 
-
-template< class Container, class Data >
-void test_unique_container(Container & c, Data & d)
+template <typename Container, typename Data>
+void test_unique_container(Container& c, Data& d)
 {
     c.clear();
-    c.insert(d.begin(),d.end());
+    c.insert(d.begin(), d.end());
     c.insert(*d.begin());
-    BOOST_CHECK( c.size() == d.size() );
+    BOOST_TEST(c.size() == d.size());
 }
 
-template< class Container, class Data >
-void test_non_unique_container(Container & c, Data & d)
+template <typename Container, typename Data>
+void test_non_unique_container(Container& c, Data& d)
 {
     c.clear();
-    c.insert(d.begin(),d.end());
+    c.insert(d.begin(), d.end());
     c.insert(*d.begin());
-    BOOST_CHECK( c.size() == (d.size()+1) );
+    BOOST_TEST(c.size() == (d.size() + 1));
 }
 
-
-
-template< class Bimap, class Data, class LeftData, class RightData >
-void test_basic_bimap( Bimap & b,
-                      const Data & d,
-                      const LeftData & ld, const RightData & rd)
+template <
+    typename Bimap, typename Data, typename LeftData, typename RightData
+>
+void
+    test_basic_bimap(
+        Bimap& b
+      , Data const& d
+      , LeftData const& ld
+      , RightData const& rd
+    )
 {
     using namespace boost::bimaps;
 
-    test_container(b,d);
+    test_container(b, d);
 
-    BOOST_CHECK( & b.left  == & b.template by<member_at::left >() );
-    BOOST_CHECK( & b.right == & b.template by<member_at::right>() );
+    BOOST_TEST(&b.left == &b.template by<member_at::left>());
+    BOOST_TEST(&b.right == &b.template by<member_at::right>());
 
-    test_container(b.left , ld);
+    test_container(b.left, ld);
     test_container(b.right, rd);
 }
 
-template< class LeftTag, class RightTag, class Bimap, class Data >
-void test_tagged_bimap(Bimap & b,
-                       const Data & d)
+template <typename LeftTag, typename RightTag, typename Bimap, typename Data>
+void test_tagged_bimap(Bimap& b, Data const& d)
 {
     using namespace boost::bimaps;
 
-    BOOST_CHECK( &b.left  == & b.template by<LeftTag >() );
-    BOOST_CHECK( &b.right == & b.template by<RightTag>() );
+    BOOST_TEST(&b.left == &b.template by<LeftTag>());
+    BOOST_TEST(&b.right == &b.template by<RightTag>());
 
     b.clear();
-    b.insert( *d.begin() );
+    b.insert(*d.begin());
 
-    BOOST_CHECK(
-        b.begin()->template get<LeftTag>() ==
-            b.template by<RightTag>().begin()->template get<LeftTag>()
+    BOOST_TEST(
+        b.begin()->template get<LeftTag>() == b.template by<
+            RightTag
+        >().begin()->template get<LeftTag>()
     );
-
-    BOOST_CHECK(
-        b.begin()->template get<RightTag>() ==
-            b.template by<LeftTag>().begin()->template get<RightTag>()
+    BOOST_TEST(
+        b.begin()->template get<RightTag>() == b.template by<
+            LeftTag
+        >().begin()->template get<RightTag>()
     );
 
     // const test
     {
+        Bimap const& bc = b;
 
-    const Bimap & bc = b;
-
-    BOOST_CHECK( &bc.left  == & bc.template by<LeftTag>() );
-    BOOST_CHECK( &bc.right == & bc.template by<RightTag>() );
-
-    BOOST_CHECK( bc.begin()->template get<LeftTag>() ==
-                    bc.template by<RightTag>().begin()->template get<LeftTag>() );
-
-    BOOST_CHECK( bc.begin()->template get<RightTag>() ==
-                    bc.template by<LeftTag>().begin()->template get<RightTag>() );
+        BOOST_TEST(&bc.left == &bc.template by<LeftTag>());
+        BOOST_TEST(&bc.right == &bc.template by<RightTag>());
+        BOOST_TEST(
+            bc.begin()->template get<LeftTag>() == bc.template by<
+                RightTag
+            >().begin()->template get<LeftTag>()
+        );
+        BOOST_TEST(
+            bc.begin()->template get<RightTag>() == bc.template by<
+                LeftTag
+            >().begin()->template get<RightTag>()
+        );
     }
 }
 
-
-template< class Bimap, class Data, class LeftData, class RightData >
-void test_set_set_bimap(Bimap & b,
-                        const Data & d,
-                        const LeftData & ld, const RightData & rd)
+template <
+    typename Bimap, typename Data, typename LeftData, typename RightData
+>
+void
+    test_set_set_bimap(
+        Bimap& b
+      , Data const& d
+      , LeftData const& ld
+      , RightData const& rd
+    )
 {
     using namespace boost::bimaps;
 
-    test_basic_bimap(b,d,ld,rd);
+    test_basic_bimap(b, d, ld, rd);
 
-    test_associative_container(b,d);
-    test_simple_ordered_associative_container(b,d);
+    test_associative_container(b, d);
+    test_simple_ordered_associative_container(b, d);
 
     test_pair_associative_container(b.left, ld);
     test_pair_ordered_associative_container(b.left, ld);
@@ -531,17 +524,22 @@ void test_set_set_bimap(Bimap & b,
 
 }
 
-
-template< class Bimap, class Data, class LeftData, class RightData >
-void test_multiset_multiset_bimap(Bimap & b,
-                                  const Data & d,
-                                  const LeftData & ld, const RightData & rd)
+template <
+    typename Bimap, typename Data, typename LeftData, typename RightData
+>
+void
+    test_multiset_multiset_bimap(
+        Bimap& b
+      , Data const& d
+      , LeftData const& ld
+      , RightData const& rd
+    )
 {
     using namespace boost::bimaps;
 
-    test_basic_bimap(b,d,ld,rd);
-    test_associative_container(b,d);
-    test_simple_ordered_associative_container(b,d);
+    test_basic_bimap(b, d, ld, rd);
+    test_associative_container(b, d);
+    test_simple_ordered_associative_container(b, d);
 
     test_pair_associative_container(b.left, ld);
     test_pair_ordered_associative_container(b.left, ld);
@@ -552,17 +550,22 @@ void test_multiset_multiset_bimap(Bimap & b,
     test_non_unique_container(b.right, rd);
 }
 
-template< class Bimap, class Data, class LeftData, class RightData >
-void test_unordered_set_unordered_multiset_bimap(Bimap & b,
-                                                 const Data & d,
-                                                 const LeftData & ld,
-                                                 const RightData & rd)
+template <
+    typename Bimap, typename Data, typename LeftData, typename RightData
+>
+void
+    test_unordered_set_unordered_multiset_bimap(
+        Bimap& b
+      , Data const& d
+      , LeftData const& ld
+      , RightData const& rd
+    )
 {
     using namespace boost::bimaps;
 
-    test_basic_bimap(b,d,ld,rd);
-    test_associative_container(b,d);
-    test_simple_unordered_associative_container(b,d);
+    test_basic_bimap(b, d, ld, rd);
+    test_associative_container(b, d);
+    test_simple_unordered_associative_container(b, d);
 
     test_pair_associative_container(b.left, ld);
     test_pair_unordered_associative_container(b.left, ld);
@@ -576,34 +579,34 @@ void test_unordered_set_unordered_multiset_bimap(Bimap & b,
     test_unique_container(b.right, rd);
 }
 
-template< class Bimap, class Data>
-void test_bimap_init_copy_swap(const Data&d)
+template <typename Bimap, typename Data>
+void test_bimap_init_copy_swap(Data const& d)
 {    
-    Bimap b1(d.begin(),d.end());
-    Bimap b2( b1 );
-    BOOST_CHECK( b1 == b2 );
+    Bimap b1(d.begin(), d.end());
+    Bimap b2(b1);
+    BOOST_TEST(b1 == b2);
     
     b2.clear();
     b2 = b1;
-    BOOST_CHECK( b2 == b1 );
+    BOOST_TEST(b2 == b1);
 
     b2.clear();
     b2.left = b1.left;
-    BOOST_CHECK( b2 == b1 );
+    BOOST_TEST(b2 == b1);
 
     b2.clear();
     b2.right = b1.right;
-    BOOST_CHECK( b2 == b1 );
+    BOOST_TEST(b2 == b1);
 
     b1.clear();
     b2.swap(b1);
-    BOOST_CHECK( b2.empty() && !b1.empty() );
+    BOOST_TEST(b2.empty() && !b1.empty());
 
-    b1.left.swap( b2.left );
-    BOOST_CHECK( b1.empty() && !b2.empty() );
+    b1.left.swap(b2.left);
+    BOOST_TEST(b1.empty() && !b2.empty());
 
-    b1.right.swap( b2.right );
-    BOOST_CHECK( b2.empty() && !b1.empty() );
+    b1.right.swap(b2.right);
+    BOOST_TEST(b2.empty() && !b1.empty());
 } 
 
 #endif // LIBS_BIMAP_TEST_BIMAP_TEST_HPP

--- a/test/test_bimap.hpp
+++ b/test/test_bimap.hpp
@@ -290,8 +290,12 @@ void test_simple_unordered_associative_container(Container& c, Data const& d)
 {
     c.clear();
     c.insert(d.begin(), d.end());
-    BOOST_TEST(c.bucket_count() * c.max_load_factor() >= d.size());
-    BOOST_TEST(c.max_bucket_count() >= c.bucket_count());
+
+    Container const& const_c = c;
+    BOOST_TEST(
+        const_c.bucket_count() * const_c.max_load_factor() >= d.size()
+    );
+    BOOST_TEST(const_c.max_bucket_count() >= const_c.bucket_count());
 
     for (
         BOOST_DEDUCED_TYPENAME Data::const_iterator di = d.begin(
@@ -310,8 +314,9 @@ void test_simple_unordered_associative_container(Container& c, Data const& d)
 
         // const
         {
-            Container const& const_c = c;
-            BOOST_TEST(const_c.bucket_size(const_c.bucket(*di)) == 1);
+            // Hash collisions should have no effect on the correctness of an
+            // unordered simple associative container. -- Cromwell D. Enage
+//            BOOST_TEST(const_c.bucket_size(const_c.bucket(*di)) == 1);
 
             BOOST_DEDUCED_TYPENAME Container::size_type nb = const_c.bucket(
                 *const_c.find(*di)
@@ -379,8 +384,12 @@ void test_pair_unordered_associative_container(Container& c, Data const& d)
 {
     c.clear();
     c.insert(d.begin(), d.end());
-    BOOST_TEST(c.bucket_count() * c.max_load_factor() >= d.size());
-    BOOST_TEST(c.max_bucket_count() >= c.bucket_count());
+
+    Container const& const_c = c;
+    BOOST_TEST(
+        const_c.bucket_count() * const_c.max_load_factor() >= d.size()
+    );
+    BOOST_TEST(const_c.max_bucket_count() >= const_c.bucket_count());
 
     for (
         BOOST_DEDUCED_TYPENAME Data::const_iterator di = d.begin(
@@ -399,8 +408,11 @@ void test_pair_unordered_associative_container(Container& c, Data const& d)
 
         // const
         {
-            Container const& const_c = c;
-            BOOST_TEST(const_c.bucket_size(const_c.bucket(di->first)) == 1);
+            // The test commented out below fails on 32-bit Windows platforms
+            // but works on 64-bit Windows platforms and others.  Regardless,
+            // hash collisions should have no effect on the correctness of an
+            // unordered pair associative container. -- Cromwell D. Enage
+//            BOOST_TEST(const_c.bucket_size(const_c.bucket(di->first)) == 1);
 
             BOOST_DEDUCED_TYPENAME Container::size_type nb = const_c.bucket(
                 const_c.find(di->first)->first

--- a/test/test_bimap_assign.cpp
+++ b/test/test_bimap_assign.cpp
@@ -17,8 +17,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // std
 #include <sstream>
@@ -37,53 +37,62 @@
 
 namespace ba =  boost::assign;
 
-
 void test_bimap_assign()
 {
     using namespace boost::bimaps;
 
     // test
     {
-        typedef bimap< list_of<int>, double > bm_type;
-        bm_type bm = ba::list_of< bm_type::relation >(1,0.1)(2,0.2)(3,0.3);
-        ba::push_back( bm )(4,0.4)(5,0.5);
-        ba::insert( bm.right )(0.5,5)(0.6,6);
-        ba::push_back( bm.left )(6,0.6)(7,0.7);
+        typedef bimap<list_of<int>,double> bm_type;
+
+        bm_type bm = ba::list_of<bm_type::relation>(1, 0.1)(2, 0.2)(3, 0.3);
+
+        ba::push_back(bm)(4, 0.4)(5, 0.5);
+        ba::insert(bm.right)(0.5, 5)(0.6, 6);
+        ba::push_back(bm.left)(6, 0.6)(7, 0.7);
     }
 
     // test
     {
-        typedef bimap< unordered_multiset_of<int>, vector_of<double>,
-                       list_of_relation > bm_type;
-        bm_type bm = ba::list_of< bm_type::relation >(1,0.1)(2,0.2)(3,0.3);
-        ba::push_front( bm )(4,0.4)(5,0.5);
-        ba::push_back( bm.right )(0.6,6)(0.7,7);
-        ba::insert( bm.left )(8,0.8)(9,0.9);
+        typedef bimap<
+            unordered_multiset_of<int>
+          , vector_of<double>
+          , list_of_relation
+        > bm_type;
+
+        bm_type bm = ba::list_of< bm_type::relation >(1, 0.1)(2, 0.2)(3, 0.3);
+
+        ba::push_front(bm)(4, 0.4)(5, 0.5);
+        ba::push_back(bm.right)(0.6, 6)(0.7, 7);
+        ba::insert(bm.left)(8, 0.8)(9, 0.9);
     }
 
     // test
     {
-        typedef bimap< int, vector_of<double>, right_based > bm_type;
-        bm_type bm = ba::list_of< bm_type::relation >(1,0.1)(2,0.2)(3,0.3);
-        ba::push_back( bm )(4,0.4)(5,0.5);
-        ba::push_back( bm.right )(0.6,6)(0.7,7);
-        ba::insert( bm.left )(8,0.8)(9,0.9);
+        typedef bimap<int,vector_of<double>,right_based> bm_type;
+
+        bm_type bm = ba::list_of<bm_type::relation>(1, 0.1)(2, 0.2)(3, 0.3);
+
+        ba::push_back(bm)(4, 0.4)(5, 0.5);
+        ba::push_back(bm.right)(0.6, 6)(0.7, 7);
+        ba::insert(bm.left)(8, 0.8)(9, 0.9);
     }
 
     // test
     {
-        typedef bimap< int, vector_of<double>, set_of_relation<> > bm_type;
-        bm_type bm = ba::list_of< bm_type::relation >(1,0.1)(2,0.2)(3,0.3);
-        ba::insert( bm )(4,0.4)(5,0.5);
-        ba::push_back( bm.right )(0.6,6)(0.7,7);
-        ba::insert( bm.left )(8,0.8)(9,0.9);
+        typedef bimap<int,vector_of<double>,set_of_relation<> > bm_type;
+
+        bm_type bm = ba::list_of<bm_type::relation>(1, 0.1)(2, 0.2)(3, 0.3);
+
+        ba::insert(bm)(4, 0.4)(5, 0.5);
+        ba::push_back(bm.right)(0.6,6)(0.7, 7);
+        ba::insert(bm.left)(8, 0.8)(9, 0.9);
     }
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_assign();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_convenience_header.cpp
+++ b/test/test_bimap_convenience_header.cpp
@@ -17,22 +17,24 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/bimap.hpp>
 
 void test_bimap_convenience_header()
 {
-    typedef boost::bimap< int, double > bm_type;
+    typedef boost::bimap<int,double> bm_type;
+
     bm_type bm;
-    bm.insert( bm_type::value_type(1,0.1) );
-    BOOST_CHECK( bm.right.at(0.1) == 1 );
+
+    bm.insert(bm_type::value_type(1, 0.1));
+    BOOST_TEST(bm.right.at(0.1) == 1);
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_convenience_header();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_extra.cpp
+++ b/test/test_bimap_extra.cpp
@@ -1,4 +1,4 @@
-  // Boost.Bimap
+// Boost.Bimap
 //
 // Copyright (c) 2006-2007 Matias Capeletto
 //
@@ -17,10 +17,10 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 // Boost.Bimap
@@ -38,61 +38,50 @@
 
 using namespace boost::bimaps;
 using namespace boost::bimaps::support;
-using namespace boost::bimaps::relation::support ;
+using namespace boost::bimaps::relation::support;
 
-typedef bimap<int, unconstrained_set_of<double> > bm_type;
+typedef bimap<int,unconstrained_set_of<double> > bm_type;
 
-namespace support_metafunctions_test {
-
-    typedef boost::is_same
-    <
-        data_type_by< member_at::left , bm_type >::type,
-        key_type_by < member_at::right, bm_type >::type
-
-    >::type test_metafunction_1;
-    BOOST_STATIC_ASSERT(test_metafunction_1::value);
-
-    typedef boost::is_same
-    <
-        data_type_by< member_at::right, bm_type >::type,
-        key_type_by < member_at::left , bm_type >::type
-
-    >::type test_metafunction_2;
-    BOOST_STATIC_ASSERT(test_metafunction_2::value);
-
-    typedef boost::is_same
-    <
-        map_type_by  < member_at::left , bm_type >::type::value_type,
-        value_type_by< member_at::left , bm_type >::type
-
-    >::type test_metafunction_3;
-    BOOST_STATIC_ASSERT(test_metafunction_3::value);
-
-    typedef boost::is_same
-    <
-        pair_type_by< member_at::left, bm_type::relation>::type,
-        value_type_by< member_at::left , bm_type >::type
-
-    >::type test_metafunction_4;
-    BOOST_STATIC_ASSERT(test_metafunction_4::value);
-    
-} // namespace support_metafunctions_test
+void test_support_metafunctions()
+{
+    BOOST_TEST_TRAIT_TRUE((
+        boost::is_same<
+            data_type_by<member_at::left,bm_type>::type
+          , key_type_by<member_at::right,bm_type>::type
+        >
+    ));
+    BOOST_TEST_TRAIT_TRUE((
+        boost::is_same<
+            data_type_by<member_at::right,bm_type>::type
+          , key_type_by<member_at::left,bm_type>::type
+        >
+    ));
+    BOOST_TEST_TRAIT_TRUE((
+        boost::is_same<
+            map_type_by<member_at::left,bm_type>::type::value_type
+          , value_type_by<member_at::left,bm_type>::type
+        >
+    ));
+    BOOST_TEST_TRAIT_TRUE((
+        boost::is_same<
+            pair_type_by<member_at::left,bm_type::relation>::type
+          , value_type_by<member_at::left,bm_type>::type
+        >
+    ));
+}
 
 void test_bimap_extra()
 {
     // extra tests
     // ---------------------------------------------------------------
-    // This section test small things... when a group of this checks
-    // can be related it is moved to a separate unit test file.
-
-
-
+    // This section tests small things... when a group of these checks
+    // can be related, they'll be moved to a separate unit test file.
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
+    test_support_metafunctions();
     test_bimap_extra();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_info.cpp
+++ b/test/test_bimap_info.cpp
@@ -17,110 +17,112 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
-
-#include <boost/config.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <string>
 
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/unordered_set_of.hpp>
 
-
 int test_bimap_info()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< double, unordered_set_of<int>, with_info<std::string> > bm_type;
+    typedef bimap<
+        double
+      , unordered_set_of<int>
+      , with_info<std::string>
+    > bm_type;
 
     bm_type bm;
-    const bm_type & cbm = bm;
+    bm_type const& cbm = bm;
 
     // Insertion with info
-    bm      .insert( bm_type::      value_type(1.1 ,   1, "one"   ) );
-    bm.left .insert( bm_type:: left_value_type(2.2 ,   2, "two"   ) );
-    bm.right.insert( bm_type::right_value_type(  3 , 3.3, "three" ) );
+    bm.insert(bm_type::value_type(1.1, 1, "one"));
+    bm.left.insert(bm_type::left_value_type(2.2, 2, "two"));
+    bm.right.insert(bm_type::right_value_type(3, 3.3, "three"));
 
     bm.begin()->info = "1";
-    BOOST_CHECK( bm.right.find(1)->info == "1" );
+    BOOST_TEST(bm.right.find(1)->info == "1");
 
     bm.left.find(2.2)->info = "2";
-    BOOST_CHECK( bm.right.find(2)->info == "2" );
+    BOOST_TEST(bm.right.find(2)->info == "2");
 
     bm.right.find(3)->info = "3";
-    BOOST_CHECK( bm.right.find(3)->info == "3" );
+    BOOST_TEST(bm.right.find(3)->info == "3");
 
     // Empty info insert
-    bm      .insert( bm_type::      value_type(4.4 ,   4) );
-    bm. left.insert( bm_type:: left_value_type(5.5 ,   5) );
-    bm.right.insert( bm_type::right_value_type(  6 , 6.6) );
+    bm.insert(bm_type::value_type(4.4, 4));
+    bm.left.insert(bm_type::left_value_type(5.5, 5));
+    bm.right.insert(bm_type::right_value_type(6, 6.6));
 
-    BOOST_CHECK( bm.right.find(4)->info == "" );
+    BOOST_TEST(bm.right.find(4)->info == "");
 
     bm.left.info_at(4.4) = "4";
-    BOOST_CHECK(  bm.right.info_at(4) == "4" );
-    BOOST_CHECK( cbm.right.info_at(4) == "4" );
+    BOOST_TEST(bm.right.info_at(4) == "4");
+    BOOST_TEST(cbm.right.info_at(4) == "4");
 
     bm.right.info_at(5) = "5";
-    BOOST_CHECK(  bm.left.info_at(5.5) == "5" );
-    BOOST_CHECK( cbm.left.info_at(5.5) == "5" );
+    BOOST_TEST(bm.left.info_at(5.5) == "5");
+    BOOST_TEST(cbm.left.info_at(5.5) == "5");
 
     return 0;
 }
 
-
-struct left  {};
+struct left {};
 struct right {};
-struct info  {};
+struct info {};
 
 int test_tagged_bimap_info()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< tagged<int,left>,
-                   tagged<int,right>,
-                   with_info<tagged<int,info> > > bm_type;
+    typedef bimap<
+        tagged<int,left>
+      , tagged<int,right>
+      , with_info<tagged<int,info> >
+    > bm_type;
 
     bm_type bm;
-    const bm_type & cbm = bm;
+    bm_type const& cbm = bm;
 
-    bm      .insert( bm_type::      value_type(1,1,1) );
-    bm.left .insert( bm_type:: left_value_type(2,2,2) );
-    bm.right.insert( bm_type::right_value_type(3,3,3) );
+    bm.insert(bm_type::value_type(1, 1, 1));
+    bm.left.insert(bm_type::left_value_type(2, 2, 2));
+    bm.right.insert(bm_type::right_value_type(3, 3, 3));
 
     bm.begin()->get<info>() = 10;
-    BOOST_CHECK( bm.right.find(1)->get<info>() == 10 );
-    BOOST_CHECK( cbm.right.find(1)->get<info>() == 10 );
+    BOOST_TEST(bm.right.find(1)->get<info>() == 10);
+    BOOST_TEST(cbm.right.find(1)->get<info>() == 10);
 
     bm.left.find(2)->get<info>() = 20;
-    BOOST_CHECK( bm.right.find(2)->get<info>() == 20 );
-    BOOST_CHECK( cbm.right.find(2)->get<info>() == 20 );
+    BOOST_TEST(bm.right.find(2)->get<info>() == 20);
+    BOOST_TEST(cbm.right.find(2)->get<info>() == 20);
 
     bm.right.find(3)->get<info>() = 30;
-    BOOST_CHECK( bm.right.find(3)->get<info>() == 30 );
-    BOOST_CHECK( cbm.right.find(3)->get<info>() == 30 );
+    BOOST_TEST(bm.right.find(3)->get<info>() == 30);
+    BOOST_TEST(cbm.right.find(3)->get<info>() == 30);
 
     // Empty info insert
-    bm      .insert( bm_type::      value_type(4,4) );
-    bm. left.insert( bm_type:: left_value_type(5,5) );
-    bm.right.insert( bm_type::right_value_type(6,6) );
+    bm.insert(bm_type::value_type(4, 4));
+    bm.left.insert(bm_type::left_value_type(5, 5));
+    bm.right.insert(bm_type::right_value_type(6, 6));
 
     bm.left.info_at(4) = 4;
-    BOOST_CHECK(  bm.right.info_at(4) == 4 );
-    BOOST_CHECK( cbm.right.info_at(4) == 4 );
+    BOOST_TEST(bm.right.info_at(4) == 4);
+    BOOST_TEST(cbm.right.info_at(4) == 4);
 
     bm.right.info_at(5) = 5;
-    BOOST_CHECK(  bm.left.info_at(5) == 5 );
-    BOOST_CHECK( cbm.left.info_at(5) == 5 );
+    BOOST_TEST(bm.left.info_at(5) == 5);
+    BOOST_TEST(cbm.left.info_at(5) == 5);
 
     return 0;
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_info();
     test_tagged_bimap_info();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_lambda.cpp
+++ b/test/test_bimap_lambda.cpp
@@ -17,8 +17,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/support/lambda.hpp>
@@ -31,17 +31,18 @@ void test_bimap_lambda()
     typedef bimap<int,double> bm;
 
     bm b;
-    b.insert( bm::value_type(1,0.1) );
 
-    BOOST_CHECK( b.size() == 1 );
-    BOOST_CHECK( b.left.modify_key ( b.left.begin(),  _key =   2 ) );
-    BOOST_CHECK( b.left.modify_data( b.left.begin(), _data = 0.2 ) );
-    BOOST_CHECK( b.left.range( _key >= 1, _key < 3 ).first == b.left.begin() );
+    b.insert(bm::value_type(1, 0.1));
+
+    BOOST_TEST(b.size() == 1);
+    BOOST_TEST(b.left.modify_key(b.left.begin(), _key = 2));
+    BOOST_TEST(b.left.modify_data(b.left.begin(), _data = 0.2));
+    BOOST_TEST(b.left.range(_key >= 1, _key < 3).first == b.left.begin());
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_lambda();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_list_of.cpp
+++ b/test/test_bimap_list_of.cpp
@@ -17,16 +17,16 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/bimap/list_of.hpp>
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
-    typedef boost::bimaps::list_of<int>     set_type;
+    typedef boost::bimaps::list_of<int> set_type;
     typedef boost::bimaps::list_of_relation set_type_of_relation;
 
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_modify.cpp
+++ b/test/test_bimap_modify.cpp
@@ -17,8 +17,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/support/lambda.hpp>
@@ -33,9 +33,9 @@ void test_bimap_modify()
     typedef bimap<int,long> bm;
 
     bm b;
-    b.insert( bm::value_type(2,200) );
+    b.insert(bm::value_type(2, 200));
 
-    BOOST_CHECK( b.left.at(2) == 200 );
+    BOOST_TEST(b.left.at(2) == 200);
 
     bool result;
 
@@ -46,97 +46,95 @@ void test_bimap_modify()
     {
         bm::left_iterator i = b.left.begin();
 
-        result = b.left.replace( i, bm::left_value_type(1,100) );
+        result = b.left.replace(i, bm::left_value_type(1, 100));
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->first == 1 && i->second == 100 );
-        BOOST_CHECK( b.left.at(1) == 100 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->first == 1) && (i->second == 100));
+        BOOST_TEST(b.left.at(1) == 100);
 
-        result = b.left.replace_key( i, 2 );
+        result = b.left.replace_key(i, 2);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->first == 2 && i->second == 100 );
-        BOOST_CHECK( b.left.at(2) == 100 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->first == 2) && (i->second == 100));
+        BOOST_TEST(b.left.at(2) == 100);
 
-        result = b.left.replace_data( i, 200 );
+        result = b.left.replace_data(i, 200);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->first == 2 && i->second == 200 );
-        BOOST_CHECK( b.left.at(2) == 200 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->first == 2) && (i->second == 200));
+        BOOST_TEST(b.left.at(2) == 200);
     }
 
     // successful replace in right map view
     {
         bm::right_iterator i = b.right.begin();
 
-        result = b.right.replace( i, bm::right_value_type(100,1) );
+        result = b.right.replace(i, bm::right_value_type(100, 1));
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->first == 100 && i->second == 1 );
-        BOOST_CHECK( b.right.at(100) == 1 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->first == 100) && (i->second == 1));
+        BOOST_TEST(b.right.at(100) == 1);
 
-        result = b.right.replace_key( i, 200 );
+        result = b.right.replace_key(i, 200);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->first == 200 && i->second == 1 );
-        BOOST_CHECK( b.right.at(200) == 1 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->first == 200) && (i->second == 1));
+        BOOST_TEST(b.right.at(200) == 1);
 
-        result = b.right.replace_data( i, 2 );
+        result = b.right.replace_data(i, 2);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->first == 200 && i->second == 2 );
-        BOOST_CHECK( b.right.at(200) == 2 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->first == 200) && (i->second == 2));
+        BOOST_TEST(b.right.at(200) == 2);
     }
 
     // successful replace in set of relations view
     {
         bm::iterator i = b.begin();
 
-        result = b.replace( i, bm::value_type(1,100) );
+        result = b.replace(i, bm::value_type(1, 100));
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->left == 1 && i->right == 100 );
-        BOOST_CHECK( b.left.at(1) == 100 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->left == 1) && (i->right == 100));
+        BOOST_TEST(b.left.at(1) == 100);
 
-        result = b.replace_left( i, 2 );
+        result = b.replace_left(i, 2);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->left == 2 && i->right == 100 );
-        BOOST_CHECK( b.left.at(2) == 100 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->left == 2) && (i->right == 100));
+        BOOST_TEST(b.left.at(2) == 100);
 
-        result = b.replace_right( b.begin(), 200 );
+        result = b.replace_right(b.begin(), 200);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->left == 2 && i->right == 200 );
-        BOOST_CHECK( b.left.at(2) == 200 );
-
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->left == 2) && (i->right == 200));
+        BOOST_TEST(b.left.at(2) == 200);
     }
 
     b.clear();
-    b.insert( bm::value_type(1,100) );
-    b.insert( bm::value_type(2,200) );
+    b.insert(bm::value_type(1, 100));
+    b.insert(bm::value_type(2, 200));
 
     // fail to replace in left map view
     {
         bm::left_iterator i = b.left.begin();
 
-        result = b.left.replace( i, bm::left_value_type(2,100) );
+        result = b.left.replace(i, bm::left_value_type(2, 100));
 
-        BOOST_CHECK( ! result );
-        BOOST_CHECK( b.size() == 2 );
-        BOOST_CHECK( i->first == 1 && i->second == 100 );
-        BOOST_CHECK( b.left.at(1) == 100 );
-        BOOST_CHECK( b.left.at(2) == 200 );
-
+        BOOST_TEST(!result);
+        BOOST_TEST(b.size() == 2);
+        BOOST_TEST((i->first == 1) && (i->second == 100));
+        BOOST_TEST(b.left.at(1) == 100);
+        BOOST_TEST(b.left.at(2) == 200);
 
         // Add checks for replace_key and replace_data
     }
@@ -150,28 +148,26 @@ void test_bimap_modify()
     // ----------------------------------------------------------------------
 
     b.clear();
-    b.insert( bm::value_type(1,100) );
+    b.insert(bm::value_type(1, 100));
 
     // successful modify in left map view
     {
-        result = b.left.modify_key( b.left.begin(), _key = 2 );
+        result = b.left.modify_key(b.left.begin(), _key = 2);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( b.left.at(2) == 100 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST(b.left.at(2) == 100);
 
-        result = b.left.modify_data( b.left.begin() , _data = 200 );
+        result = b.left.modify_data(b.left.begin(), _data = 200);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( b.left.at(2) == 200 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST(b.left.at(2) == 200);
     }
 
     // Add checks for successful modify in right map view
 
     // Add checks for fails to modify in left map view
-
-
 }
 
 void test_bimap_replace_with_info() 
@@ -180,70 +176,68 @@ void test_bimap_replace_with_info()
     typedef bimap<int,long,with_info<int> > bm;
 
     bm b;
-    b.insert( bm::value_type(2,200,-2) );
+    b.insert(bm::value_type(2, 200, -2));
 
-    BOOST_CHECK( b.left.at(2)      == 200 );
-    BOOST_CHECK( b.left.info_at(2) ==  -2 );
+    BOOST_TEST(b.left.at(2) == 200);
+    BOOST_TEST(b.left.info_at(2) == -2);
  
     // Use set view
     {
         bm::iterator i = b.begin();
 
-        bool result = b.replace( i, bm::value_type(1,100,-1) );
+        bool result = b.replace(i, bm::value_type(1, 100, -1));
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->left == 1 && i->right == 100 );
-        BOOST_CHECK( i->info == -1 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->left == 1) && (i->right == 100));
+        BOOST_TEST(i->info == -1);
         
-        result = b.replace_left( i, 2 );
+        result = b.replace_left(i, 2);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->left == 2 && i->right == 100 );
-        BOOST_CHECK( i->info == -1 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->left == 2) && (i->right == 100));
+        BOOST_TEST(i->info == -1);
         
-        result = b.replace_right( i, 200 );
+        result = b.replace_right(i, 200);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.size() == 1 );
-        BOOST_CHECK( i->left == 2 && i->right == 200 );
-        BOOST_CHECK( i->info == -1 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST((i->left == 2) && (i->right == 200));
+        BOOST_TEST(i->info == -1);
     }
 
     // Use map view
     {
         bm::left_iterator i = b.left.begin();
 
-        bool result = b.left.replace( i, bm::left_value_type(1,100,-1) );
+        bool result = b.left.replace(i, bm::left_value_type(1, 100, -1));
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.left.size() == 1 );
-        BOOST_CHECK( i->first == 1 && i->second == 100 );
-        BOOST_CHECK( i->info == -1 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.left.size() == 1);
+        BOOST_TEST((i->first == 1) && (i->second == 100));
+        BOOST_TEST(i->info == -1);
         
-        result = b.left.replace_key( i, 2 );
+        result = b.left.replace_key(i, 2);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.left.size() == 1 );
-        BOOST_CHECK( i->first == 2 && i->second == 100 );
-        BOOST_CHECK( i->info == -1 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.left.size() == 1);
+        BOOST_TEST((i->first == 2) && (i->second == 100));
+        BOOST_TEST(i->info == -1);
         
-        result = b.left.replace_data( i, 200 );
+        result = b.left.replace_data(i, 200);
 
-        BOOST_CHECK( result );
-        BOOST_CHECK( b.left.size() == 1 );
-        BOOST_CHECK( i->first == 2 && i->second == 200 );
-        BOOST_CHECK( i->info == -1 );
+        BOOST_TEST(result);
+        BOOST_TEST(b.left.size() == 1);
+        BOOST_TEST((i->first == 2) && (i->second == 200));
+        BOOST_TEST(i->info == -1);
     }
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_modify();
-
     test_bimap_replace_with_info();
-    
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_modify.cpp
+++ b/test/test_bimap_modify.cpp
@@ -24,7 +24,9 @@
 #include <boost/bimap/support/lambda.hpp>
 #include <boost/bimap/bimap.hpp>
 
-struct id{};
+struct id
+{
+};
 
 void test_bimap_modify()
 {
@@ -139,7 +141,20 @@ void test_bimap_modify()
         // Add checks for replace_key and replace_data
     }
 
-    // Add checks for fail to replace in right map view
+    // fail to replace in right map view
+    {
+        bm::right_iterator i = b.right.begin();
+
+        result = b.right.replace(i, bm::right_value_type(100, 2));
+
+        BOOST_TEST(!result);
+        BOOST_TEST(b.size() == 2);
+        BOOST_TEST((i->first == 100) && (i->second == 1));
+        BOOST_TEST(b.right.at(100) == 1);
+        BOOST_TEST(b.right.at(200) == 2);
+
+        // Add checks for replace_key and replace_data
+    }
 
     // Add checks for fail to replace in set of relations view
 
@@ -165,7 +180,20 @@ void test_bimap_modify()
         BOOST_TEST(b.left.at(2) == 200);
     }
 
-    // Add checks for successful modify in right map view
+    // successful modify in right map view
+    {
+        result = b.right.modify_key(b.right.begin(), _key = 100);
+
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST(b.right.at(100) == 2);
+
+        result = b.right.modify_data(b.right.begin(), _data = 1);
+
+        BOOST_TEST(result);
+        BOOST_TEST(b.size() == 1);
+        BOOST_TEST(b.right.at(100) == 1);
+    }
 
     // Add checks for fails to modify in left map view
 }

--- a/test/test_bimap_multiset_of.cpp
+++ b/test/test_bimap_multiset_of.cpp
@@ -17,16 +17,16 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/bimap/multiset_of.hpp>
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
-    typedef boost::bimaps::multiset_of<int>       set_type;
+    typedef boost::bimaps::multiset_of<int> set_type;
     typedef boost::bimaps::multiset_of_relation<> set_type_of_relation;
 
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_mutable.cpp
+++ b/test/test_bimap_mutable.cpp
@@ -1,4 +1,4 @@
-  // Boost.Bimap
+// Boost.Bimap
 //
 // Copyright (c) 2006-2007 Matias Capeletto
 //
@@ -17,8 +17,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/bimap.hpp>
@@ -28,82 +28,82 @@
 
 using namespace boost::bimaps;
 
-template< class BimapType >
+template <typename BimapType>
 void test_bimap_mutable()
 {
     typedef BimapType bm_type;
 
     bm_type bm;
-    bm.insert( BOOST_DEDUCED_TYPENAME bm_type::value_type(1,0.1) );
+    bm.insert(BOOST_DEDUCED_TYPENAME bm_type::value_type(1, 0.1));
 
-    const bm_type & cbm = bm;
+    bm_type const& cbm = bm;
 
     // Map Mutable Iterator test
     {
+        BOOST_DEDUCED_TYPENAME bm_type::left_iterator iter = bm.left.begin();
+        iter->second = 0.2;
+        BOOST_TEST(iter->second == bm.left.begin()->second);
 
-    BOOST_DEDUCED_TYPENAME bm_type::left_iterator iter = bm.left.begin();
-    iter->second = 0.2;
-    BOOST_CHECK( iter->second == bm.left.begin()->second );
+        BOOST_DEDUCED_TYPENAME bm_type::left_const_iterator citer = (
+            bm.left.begin()
+        );
+        BOOST_TEST(citer->second == bm.left.begin()->second);
 
-    BOOST_DEDUCED_TYPENAME bm_type::left_const_iterator citer = bm.left.begin();
-    BOOST_CHECK( citer->second == bm.left.begin()->second );
-
-    BOOST_DEDUCED_TYPENAME bm_type::left_const_iterator cciter = cbm.left.begin();
-    BOOST_CHECK( cciter->second == cbm.left.begin()->second );
-
+        BOOST_DEDUCED_TYPENAME bm_type::left_const_iterator cciter = (
+            cbm.left.begin()
+        );
+        BOOST_TEST(cciter->second == cbm.left.begin()->second);
     }
 
     // Set Mutable Iterator test
     {
+        BOOST_DEDUCED_TYPENAME bm_type::iterator iter = bm.begin();
+        iter->right = 0.1;
+        BOOST_TEST(iter->right == bm.begin()->right);
 
-    BOOST_DEDUCED_TYPENAME bm_type::iterator iter = bm.begin();
-    iter->right = 0.1;
-    BOOST_CHECK( iter->right == bm.begin()->right );
+        BOOST_DEDUCED_TYPENAME bm_type::const_iterator citer = bm.begin();
+        BOOST_TEST(citer->right == bm.begin()->right);
 
-    BOOST_DEDUCED_TYPENAME bm_type::const_iterator citer = bm.begin();
-    BOOST_CHECK( citer->right == bm.begin()->right );
-
-    BOOST_DEDUCED_TYPENAME bm_type::const_iterator cciter = cbm.begin();
-    BOOST_CHECK( cciter->left == cbm.begin()->left );
-
+        BOOST_DEDUCED_TYPENAME bm_type::const_iterator cciter = cbm.begin();
+        BOOST_TEST(cciter->left == cbm.begin()->left);
     }
 
     // Map Assignable Reference test
     {
+        BOOST_DEDUCED_TYPENAME bm_type::left_reference r = *bm.left.begin();
+        r.second = 0.2;
+        BOOST_TEST(r == *bm.left.begin());
 
-    BOOST_DEDUCED_TYPENAME bm_type::left_reference r = *bm.left.begin();
-    r.second = 0.2;
-    BOOST_CHECK( r == *bm.left.begin() );
+        BOOST_DEDUCED_TYPENAME bm_type::left_const_reference cr = *(
+            bm.left.begin()
+        );
+        BOOST_TEST(cr == *bm.left.begin());
 
-    BOOST_DEDUCED_TYPENAME bm_type::left_const_reference cr = *bm.left.begin();
-    BOOST_CHECK( cr == *bm.left.begin() );
-
-    BOOST_DEDUCED_TYPENAME bm_type::left_const_reference ccr = *cbm.left.begin();
-    BOOST_CHECK( ccr == *cbm.left.begin() );
-
+        BOOST_DEDUCED_TYPENAME bm_type::left_const_reference ccr = *(
+            cbm.left.begin()
+        );
+        BOOST_TEST(ccr == *cbm.left.begin());
     }
 
     // Set Assignable Reference test
     {
+        BOOST_DEDUCED_TYPENAME bm_type::reference r = *bm.begin();
+        r.right = 0.1;
+        BOOST_TEST(r == *bm.begin());
 
-    BOOST_DEDUCED_TYPENAME bm_type::reference r = *bm.begin();
-    r.right = 0.1;
-    BOOST_CHECK( r == *bm.begin() );
+        BOOST_DEDUCED_TYPENAME bm_type::const_reference cr = *bm.begin();
+        BOOST_TEST(cr == *bm.begin());
 
-    BOOST_DEDUCED_TYPENAME bm_type::const_reference cr = *bm.begin();
-    BOOST_CHECK( cr == *bm.begin() );
-
-    BOOST_DEDUCED_TYPENAME bm_type::const_reference ccr = *cbm.begin();
-    BOOST_CHECK( ccr == *bm.begin() );
-
+        BOOST_DEDUCED_TYPENAME bm_type::const_reference ccr = *cbm.begin();
+        BOOST_TEST(ccr == *bm.begin());
     }
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
-    test_bimap_mutable< bimap< int, list_of<double> > >();
-    test_bimap_mutable< bimap< int, vector_of<double> > >();
-    test_bimap_mutable< bimap< int, unconstrained_set_of<double> > >();
-    return 0;
+    test_bimap_mutable<bimap<int,list_of<double> > >();
+    test_bimap_mutable<bimap<int,vector_of<double> > >();
+    test_bimap_mutable<bimap<int,unconstrained_set_of<double> > >();
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_operator_bracket.cpp
+++ b/test/test_bimap_operator_bracket.cpp
@@ -17,8 +17,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/support/lambda.hpp>
@@ -28,166 +28,172 @@
 #include <boost/bimap/vector_of.hpp>
 #include <boost/bimap/unconstrained_set_of.hpp>
 
-
 void test_bimap_operator_bracket()
 {
     using namespace boost::bimaps;
 
     // Simple test
     {
-        typedef bimap< int, std::string > bm;
+        typedef bimap<int,std::string> bm;
 
         bm b;
-        b.insert( bm::value_type(0,"0") );
-        b.insert( bm::value_type(1,"1") );
-        b.insert( bm::value_type(2,"2") );
-        b.insert( bm::value_type(3,"3") );
 
-        BOOST_CHECK( b.left.at(1) == "1" );
+        b.insert(bm::value_type(0, "0"));
+        b.insert(bm::value_type(1, "1"));
+        b.insert(bm::value_type(2, "2"));
+        b.insert(bm::value_type(3, "3"));
+
+        BOOST_TEST(b.left.at(1) == "1");
 
         // Out of range test
         {
             bool value_not_found_test_passed = false;
             b.clear();
+
             try
             {
                 bool comp;
                 comp = b.left.at(2) < "banana";
             }
-            catch( std::out_of_range & )
+            catch (std::out_of_range&)
             {
                 value_not_found_test_passed = true;
             }
 
-            BOOST_CHECK( value_not_found_test_passed );
+            BOOST_TEST(value_not_found_test_passed);
         }
     }
 
     // Mutable data test (1)
     {
-        typedef bimap<int, list_of<std::string> > bm;
+        typedef bimap<int,list_of<std::string> > bm;
+
         bm b;
 
         // Out of range test
         {
             bool value_not_found_test_passed = false;
             b.clear();
+
             try
             {
                 bool comp;
                 comp = b.left.at(1) < "banana";
             }
-            catch( std::out_of_range & )
+            catch (std::out_of_range&)
             {
                 value_not_found_test_passed = true;
             }
 
-            BOOST_CHECK( value_not_found_test_passed );
-
+            BOOST_TEST(value_not_found_test_passed);
         }
 
         // Out of range test (const version)
         {
             bool value_not_found_test_passed = false;
             b.clear();
+
             try
             {
-                const bm & cb(b);
+                bm const& cb(b);
                 bool comp;
                 comp = cb.left.at(1) < "banana";
             }
-            catch( std::out_of_range & )
+            catch (std::out_of_range&)
             {
                 value_not_found_test_passed = true;
             }
 
-            BOOST_CHECK( value_not_found_test_passed );
+            BOOST_TEST(value_not_found_test_passed);
         }
 
-        BOOST_CHECK( b.left[1]    == "" );
-        BOOST_CHECK( b.left.at(1) == "" );
+        BOOST_TEST(b.left[1] == "");
+        BOOST_TEST(b.left.at(1) == "");
         b.left[2] = "two";
-        BOOST_CHECK( b.left.at(2) == "two" );
+        BOOST_TEST(b.left.at(2) == "two");
         b.left[2] = "<<two>>";
-        BOOST_CHECK( b.left.at(2) == "<<two>>" );
+        BOOST_TEST(b.left.at(2) == "<<two>>");
         b.left.at(2) = "two";
-        BOOST_CHECK( b.left.at(2) == "two" );
-
+        BOOST_TEST(b.left.at(2) == "two");
     }
 
     // Mutable data test (2)
     {
-        typedef bimap< vector_of<int>, unordered_set_of<std::string> > bm;
+        typedef bimap<vector_of<int>,unordered_set_of<std::string> > bm;
         bm b;
 
         // Out of range test
         {
             bool value_not_found_test_passed = false;
             b.clear();
+
             try
             {
                 bool comp;
                 comp = b.right.at("banana") < 1;
             }
-            catch( std::out_of_range & )
+            catch (std::out_of_range&)
             {
                 value_not_found_test_passed = true;
             }
-            BOOST_CHECK( value_not_found_test_passed );
+
+            BOOST_TEST(value_not_found_test_passed);
         }
 
         // Out of range test (const version)
         {
             bool value_not_found_test_passed = false;
             b.clear();
+
             try
             {
-                const bm & cb(b);
+                bm const& cb(b);
                 bool comp;
                 comp = cb.right.at("banana") < 1;
             }
-            catch( std::out_of_range & )
+            catch (std::out_of_range&)
             {
                 value_not_found_test_passed = true;
             }
 
-            BOOST_CHECK( value_not_found_test_passed );
+            BOOST_TEST(value_not_found_test_passed);
         }
 
         b.right["one"];
-        BOOST_CHECK( b.size() == 1 );
+        BOOST_TEST(b.size() == 1);
         b.right["two"] = 2;
-        BOOST_CHECK( b.right.at("two") == 2 );
+        BOOST_TEST(b.right.at("two") == 2);
         b.right["two"] = -2;
-        BOOST_CHECK( b.right.at("two") == -2 );
+        BOOST_TEST(b.right.at("two") == -2);
         b.right.at("two") = 2;
-        BOOST_CHECK( b.right.at("two") == 2 );
+        BOOST_TEST(b.right.at("two") == 2);
     }
 
     // Mutable data test (3)
     {
-        typedef bimap< unconstrained_set_of<int>,
-                       unordered_set_of<std::string>,
-                       right_based                       > bm;
+        typedef bimap<
+            unconstrained_set_of<int>
+          , unordered_set_of<std::string>
+          , right_based
+        > bm;
 
         bm b;
 
         b.right["one"];
-        BOOST_CHECK( b.size() == 1 );
+        BOOST_TEST(b.size() == 1);
         b.right["two"] = 2;
-        BOOST_CHECK( b.right.at("two") == 2 );
+        BOOST_TEST(b.right.at("two") == 2);
         b.right["two"] = -2;
-        BOOST_CHECK( b.right.at("two") == -2 );
+        BOOST_TEST(b.right.at("two") == -2);
         b.right.at("two") = 2;
-        BOOST_CHECK( b.right.at("two") == 2 );
+        BOOST_TEST(b.right.at("two") == 2);
     }
 
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_operator_bracket();
-
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_ordered.cpp
+++ b/test/test_bimap_ordered.cpp
@@ -19,9 +19,6 @@
 
 #define BOOST_BIMAP_DISABLE_SERIALIZATION
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
-
 // std
 #include <set>
 #include <map>
@@ -35,9 +32,9 @@
 // bimap container
 #include <boost/bimap/bimap.hpp>
 
-#include <libs/bimap/test/test_bimap.hpp>
+#include "test_bimap.hpp"
 
-struct  left_tag {};
+struct left_tag {};
 struct right_tag {};
 
 void test_bimap()
@@ -46,131 +43,122 @@ void test_bimap()
 
     typedef std::map<int,double> left_data_type;
     left_data_type left_data;
-    left_data.insert( left_data_type::value_type(1,0.1) );
-    left_data.insert( left_data_type::value_type(2,0.2) );
-    left_data.insert( left_data_type::value_type(3,0.3) );
-    left_data.insert( left_data_type::value_type(4,0.4) );
+    left_data.insert(left_data_type::value_type(1, 0.1));
+    left_data.insert(left_data_type::value_type(2, 0.2));
+    left_data.insert(left_data_type::value_type(3, 0.3));
+    left_data.insert(left_data_type::value_type(4, 0.4));
 
     typedef std::map<double,int> right_data_type;
     right_data_type right_data;
-    right_data.insert( right_data_type::value_type(0.1,1) );
-    right_data.insert( right_data_type::value_type(0.2,2) );
-    right_data.insert( right_data_type::value_type(0.3,3) );
-    right_data.insert( right_data_type::value_type(0.4,4) );
-
+    right_data.insert(right_data_type::value_type(0.1, 1));
+    right_data.insert(right_data_type::value_type(0.2, 2));
+    right_data.insert(right_data_type::value_type(0.3, 3));
+    right_data.insert(right_data_type::value_type(0.4, 4));
 
     //--------------------------------------------------------------------
     {
-        typedef bimap< int, double > bm_type;
+        typedef bimap<int,double> bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type(1,0.1) );
-        data.insert( bm_type::value_type(2,0.2) );
-        data.insert( bm_type::value_type(3,0.3) );
-        data.insert( bm_type::value_type(4,0.4) );
+        std::set<bm_type::value_type> data;
+        data.insert(bm_type::value_type(1, 0.1));
+        data.insert(bm_type::value_type(2, 0.2));
+        data.insert(bm_type::value_type(3, 0.3));
+        data.insert(bm_type::value_type(4, 0.4));
 
         bm_type bm;
-        test_set_set_bimap(bm,data,left_data,right_data);
+        test_set_set_bimap(bm, data, left_data, right_data);
     }
     //--------------------------------------------------------------------
 
-
     //--------------------------------------------------------------------
     {
-        typedef bimap
-        <
-            multiset_of< tagged<int, left_tag > >,
-            multiset_of< tagged<double, right_tag > >,
-            multiset_of_relation< std::less< _relation > >
-
+        typedef bimap<
+            multiset_of<tagged<int,left_tag> >
+          , multiset_of<tagged<double,right_tag> >
+          , multiset_of_relation<std::less<_relation> >
         > bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type(1,0.1) );
-        data.insert( bm_type::value_type(2,0.2) );
-        data.insert( bm_type::value_type(3,0.3) );
-        data.insert( bm_type::value_type(4,0.4) );
+        std::set<bm_type::value_type> data;
+        data.insert(bm_type::value_type(1, 0.1));
+        data.insert(bm_type::value_type(2, 0.2));
+        data.insert(bm_type::value_type(3, 0.3));
+        data.insert(bm_type::value_type(4, 0.4));
 
         bm_type bm;
 
-        test_multiset_multiset_bimap(bm,data,left_data,right_data);
-        test_tagged_bimap<left_tag,right_tag>(bm,data);
+        test_multiset_multiset_bimap(bm, data, left_data, right_data);
+        test_tagged_bimap<left_tag,right_tag>(bm, data);
     }
     //--------------------------------------------------------------------
-
 
     //--------------------------------------------------------------------
     {
         typedef bimap<int,double,right_based> bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type(1,0.1) );
-        data.insert( bm_type::value_type(2,0.2) );
-        data.insert( bm_type::value_type(3,0.3) );
-        data.insert( bm_type::value_type(4,0.4) );
+        std::set<bm_type::value_type> data;
+        data.insert(bm_type::value_type(1, 0.1));
+        data.insert(bm_type::value_type(2, 0.2));
+        data.insert(bm_type::value_type(3, 0.3));
+        data.insert(bm_type::value_type(4, 0.4));
 
         bm_type bm;
 
-        test_set_set_bimap(bm,data,left_data,right_data);
+        test_set_set_bimap(bm, data, left_data, right_data);
     }
     //--------------------------------------------------------------------
 
-
     //--------------------------------------------------------------------
     {
-        typedef bimap
-        <
-            multiset_of< int, std::greater<int> >, set_of<std::string> ,
-            multiset_of_relation< std::greater< _relation > >
-
+        typedef bimap<
+            multiset_of<int,std::greater<int> >
+          , set_of<std::string>
+          , multiset_of_relation<std::greater<_relation> >
         > bimap_type;
 
         bimap_type b1;
 
-        b1.insert( bimap_type::value_type(1,"one") );
+        b1.insert(bimap_type::value_type(1, "one"));
 
-        bimap_type b2( b1 );
+        bimap_type b2(b1);
 
-        BOOST_CHECK(     b1 == b2   );
-        BOOST_CHECK( ! ( b1 != b2 ) );
-        BOOST_CHECK(     b1 <= b2   );
-        BOOST_CHECK(     b1 >= b2   );
-        BOOST_CHECK( ! ( b1 <  b2 ) );
-        BOOST_CHECK( ! ( b1 >  b2 ) );
+        BOOST_TEST(b1 == b2);
+        BOOST_TEST(!(b1 != b2));
+        BOOST_TEST(b1 <= b2);
+        BOOST_TEST(b1 >= b2);
+        BOOST_TEST(!(b1 < b2));
+        BOOST_TEST(!(b1 > b2));
 
-        b1.insert( bimap_type::value_type(2,"two") );
+        b1.insert(bimap_type::value_type(2, "two"));
 
         b2 = b1;
-        BOOST_CHECK( b2 == b1 );
+        BOOST_TEST(b2 == b1);
 
-        b1.insert( bimap_type::value_type(3,"three") );
+        b1.insert(bimap_type::value_type(3, "three"));
 
         b2.left = b1.left;
-        BOOST_CHECK( b2 == b1 );
+        BOOST_TEST(b2 == b1);
 
-        b1.insert( bimap_type::value_type(4,"four") );
+        b1.insert(bimap_type::value_type(4, "four"));
 
         b2.right = b1.right;
-        BOOST_CHECK( b2 == b1 );
+        BOOST_TEST(b2 == b1);
 
         b1.clear();
         b2.swap(b1);
-        BOOST_CHECK( b2.empty() && !b1.empty() );
+        BOOST_TEST(b2.empty() && !b1.empty());
 
-        b1.left.swap( b2.left );
-        BOOST_CHECK( b1.empty() && !b2.empty() );
+        b1.left.swap(b2.left);
+        BOOST_TEST(b1.empty() && !b2.empty());
 
-        b1.right.swap( b2.right );
-        BOOST_CHECK( b2.empty() && !b1.empty() );
+        b1.right.swap(b2.right);
+        BOOST_TEST(b2.empty() && !b1.empty());
     }
     //--------------------------------------------------------------------
-
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_project.cpp
+++ b/test/test_bimap_project.cpp
@@ -1,4 +1,4 @@
-  // Boost.Bimap
+// Boost.Bimap
 //
 // Copyright (c) 2006-2007 Matias Capeletto
 //
@@ -17,8 +17,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <string>
 
@@ -28,116 +28,112 @@
 
 using namespace boost::bimaps;
 
-struct  left_tag {};
+struct left_tag {};
 struct right_tag {};
 
 void test_bimap_project()
 {
-    typedef bimap
-    <
-                 tagged< int        ,  left_tag >,
-        list_of< tagged< std::string, right_tag > >
-
+    typedef bimap<
+        tagged<int,left_tag>
+      , list_of<tagged<std::string,right_tag> >
     > bm_type;
 
     bm_type bm;
 
-    bm.insert( bm_type::value_type(1,"1") );
-    bm.insert( bm_type::value_type(2,"2") );
+    bm.insert(bm_type::value_type(1, "1"));
+    bm.insert(bm_type::value_type(2, "2"));
 
-    bm_type::      iterator       iter = bm.begin();
-    bm_type:: left_iterator  left_iter = bm.left.find(1);
+    bm_type::iterator iter = bm.begin();
+    bm_type::left_iterator left_iter = bm.left.find(1);
     bm_type::right_iterator right_iter = bm.right.begin();
 
-    const bm_type & cbm = bm;
+    bm_type const& cbm = bm;
 
-    bm_type::      const_iterator       citer = cbm.begin();
-    bm_type:: left_const_iterator  left_citer = cbm.left.find(1);
+    bm_type::const_iterator citer = cbm.begin();
+    bm_type::left_const_iterator left_citer = cbm.left.find(1);
     bm_type::right_const_iterator right_citer = cbm.right.begin();
 
     // non const projection
 
-    BOOST_CHECK( bm.project_up   (bm.end()) == bm.end()       );
-    BOOST_CHECK( bm.project_left (bm.end()) == bm.left.end()  );
-    BOOST_CHECK( bm.project_right(bm.end()) == bm.right.end() );
+    BOOST_TEST(bm.project_up(bm.end()) == bm.end());
+    BOOST_TEST(bm.project_left(bm.end()) == bm.left.end());
+    BOOST_TEST(bm.project_right(bm.end()) == bm.right.end());
 
-    BOOST_CHECK( bm.project_up   (iter) == iter       );
-    BOOST_CHECK( bm.project_left (iter) == left_iter  );
-    BOOST_CHECK( bm.project_right(iter) == right_iter );
+    BOOST_TEST(bm.project_up(iter) == iter);
+    BOOST_TEST(bm.project_left(iter) == left_iter);
+    BOOST_TEST(bm.project_right(iter) == right_iter);
 
-    BOOST_CHECK( bm.project_up   (left_iter) == iter       );
-    BOOST_CHECK( bm.project_left (left_iter) == left_iter  );
-    BOOST_CHECK( bm.project_right(left_iter) == right_iter );
+    BOOST_TEST(bm.project_up(left_iter) == iter);
+    BOOST_TEST(bm.project_left(left_iter) == left_iter);
+    BOOST_TEST(bm.project_right(left_iter) == right_iter);
 
-    BOOST_CHECK( bm.project_up   (right_iter) == iter       );
-    BOOST_CHECK( bm.project_left (right_iter) == left_iter  );
-    BOOST_CHECK( bm.project_right(right_iter) == right_iter );
+    BOOST_TEST(bm.project_up(right_iter) == iter);
+    BOOST_TEST(bm.project_left(right_iter) == left_iter);
+    BOOST_TEST(bm.project_right(right_iter) == right_iter);
 
-    bm.project_up   ( left_iter)->right  = "u";
-    bm.project_left (right_iter)->second = "l";
-    bm.project_right(      iter)->first  = "r";
+    bm.project_up(left_iter)->right = "u";
+    bm.project_left(right_iter)->second = "l";
+    bm.project_right(iter)->first = "r";
 
     // const projection
 
-    BOOST_CHECK( cbm.project_up   (cbm.end()) == cbm.end()       );
-    BOOST_CHECK( cbm.project_left (cbm.end()) == cbm.left.end()  );
-    BOOST_CHECK( cbm.project_right(cbm.end()) == cbm.right.end() );
+    BOOST_TEST(cbm.project_up(cbm.end()) == cbm.end());
+    BOOST_TEST(cbm.project_left(cbm.end()) == cbm.left.end());
+    BOOST_TEST(cbm.project_right(cbm.end()) == cbm.right.end());
 
-    BOOST_CHECK( cbm.project_up   (citer) == citer       );
-    BOOST_CHECK( cbm.project_left (citer) == left_citer  );
-    BOOST_CHECK( cbm.project_right(citer) == right_citer );
+    BOOST_TEST(cbm.project_up(citer) == citer);
+    BOOST_TEST(cbm.project_left(citer) == left_citer);
+    BOOST_TEST(cbm.project_right(citer) == right_citer);
 
-    BOOST_CHECK( cbm.project_up   (left_citer) == citer       );
-    BOOST_CHECK( cbm.project_left (left_citer) == left_citer  );
-    BOOST_CHECK( cbm.project_right(left_citer) == right_citer );
+    BOOST_TEST(cbm.project_up(left_citer) == citer);
+    BOOST_TEST(cbm.project_left(left_citer) == left_citer);
+    BOOST_TEST(cbm.project_right(left_citer) == right_citer);
 
-    BOOST_CHECK( cbm.project_up   (right_citer) == citer       );
-    BOOST_CHECK( cbm.project_left (right_citer) == left_citer  );
-    BOOST_CHECK( cbm.project_right(right_citer) == right_citer );
+    BOOST_TEST(cbm.project_up(right_citer) == citer);
+    BOOST_TEST(cbm.project_left(right_citer) == left_citer);
+    BOOST_TEST(cbm.project_right(right_citer) == right_citer);
 
     // mixed projection
 
-    BOOST_CHECK( bm.project_up   (left_citer) == iter       );
-    BOOST_CHECK( bm.project_left (left_citer) == left_iter  );
-    BOOST_CHECK( bm.project_right(left_citer) == right_iter );
+    BOOST_TEST(bm.project_up(left_citer) == iter);
+    BOOST_TEST(bm.project_left(left_citer) == left_iter);
+    BOOST_TEST(bm.project_right(left_citer) == right_iter);
 
-    BOOST_CHECK( cbm.project_up   (right_iter) == citer       );
-    BOOST_CHECK( cbm.project_left (right_iter) == left_citer  );
-    BOOST_CHECK( cbm.project_right(right_iter) == right_citer );
+    BOOST_TEST(cbm.project_up(right_iter) == citer);
+    BOOST_TEST(cbm.project_left(right_iter) == left_citer);
+    BOOST_TEST(cbm.project_right(right_iter) == right_citer);
 
-    bm.project_up   ( left_citer)->right  = "u";
-    bm.project_left (right_citer)->second = "l";
-    bm.project_right(      citer)->first  = "r";
+    bm.project_up(left_citer)->right = "u";
+    bm.project_left(right_citer)->second = "l";
+    bm.project_right(citer)->first = "r";
 
     // Support for tags
 
-    BOOST_CHECK( bm.project< left_tag>(iter) == left_iter  );
-    BOOST_CHECK( bm.project<right_tag>(iter) == right_iter );
+    BOOST_TEST(bm.project<left_tag>(iter) == left_iter);
+    BOOST_TEST(bm.project<right_tag>(iter) == right_iter);
 
-    BOOST_CHECK( bm.project< left_tag>(left_iter) == left_iter  );
-    BOOST_CHECK( bm.project<right_tag>(left_iter) == right_iter );
+    BOOST_TEST(bm.project<left_tag>(left_iter) == left_iter);
+    BOOST_TEST(bm.project<right_tag>(left_iter) == right_iter);
 
-    BOOST_CHECK( bm.project< left_tag>(right_iter) == left_iter  );
-    BOOST_CHECK( bm.project<right_tag>(right_iter) == right_iter );
+    BOOST_TEST(bm.project<left_tag>(right_iter) == left_iter);
+    BOOST_TEST(bm.project<right_tag>(right_iter) == right_iter);
 
-    BOOST_CHECK( cbm.project< left_tag>(citer) == left_citer  );
-    BOOST_CHECK( cbm.project<right_tag>(citer) == right_citer );
+    BOOST_TEST(cbm.project<left_tag>(citer) == left_citer);
+    BOOST_TEST(cbm.project<right_tag>(citer) == right_citer);
 
-    BOOST_CHECK( cbm.project< left_tag>(left_citer) == left_citer  );
-    BOOST_CHECK( cbm.project<right_tag>(left_citer) == right_citer );
+    BOOST_TEST(cbm.project<left_tag>(left_citer) == left_citer);
+    BOOST_TEST(cbm.project<right_tag>(left_citer) == right_citer);
 
-    BOOST_CHECK( cbm.project< left_tag>(right_citer) == left_citer  );
-    BOOST_CHECK( cbm.project<right_tag>(right_citer) == right_citer );
+    BOOST_TEST(cbm.project<left_tag>(right_citer) == left_citer);
+    BOOST_TEST(cbm.project<right_tag>(right_citer) == right_citer);
 
-    bm.project< left_tag>(right_citer)->second = "l";
-    bm.project<right_tag>( left_citer)->first  = "r";
-
+    bm.project<left_tag>(right_citer)->second = "l";
+    bm.project<right_tag>(left_citer)->first = "r";
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_project();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_property_map.cpp
+++ b/test/test_bimap_property_map.cpp
@@ -16,6 +16,7 @@
 #define _SCL_SECURE_NO_DEPRECATE
 
 #include <boost/config.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 
 // std
 #include <set>
@@ -25,7 +26,8 @@
 #include <algorithm>
 
 // Boost.Test
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 // Boost.Bimap
 
@@ -37,40 +39,49 @@
 
 #include <boost/bimap/bimap.hpp>
 
-
-template <class Map>
-void test_readable_property_map(
-    Map m,
-    typename boost::property_traits<Map>::  key_type const & key,
-    typename boost::property_traits<Map>::value_type const & value
-)
+template <typename Map>
+void
+    test_readable_property_map(
+        Map m
+      , BOOST_DEDUCED_TYPENAME boost::property_traits<
+            Map
+        >::key_type const& key
+      , BOOST_DEDUCED_TYPENAME boost::property_traits<
+            Map
+        >::value_type const& value
+    )
 {
-    // TODO Add STATIC_ASSERT(
-    //              boost::property_traits<Map>::category is readable )
+    BOOST_TEST_TRAIT_TRUE((
+        boost::is_convertible<
+            BOOST_DEDUCED_TYPENAME boost::property_traits<Map>::category
+          , boost::readable_property_map_tag
+        >
+    ));
 
-    BOOST_CHECK( get(m,key) == value );
-    //BOOST_CHECK( m[key]     == value );
+    BOOST_TEST(get(m, key) == value);
+#if 0
+    BOOST_TEST(m[key] == value);
+#endif
 }
-
 
 void test_bimap_property_map()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< set_of<int>, unordered_set_of<double> > bm;
+    typedef bimap<set_of<int>,unordered_set_of<double> > bm;
 
     bm b;
-    b.insert( bm::value_type(1,0.1) );
-    b.insert( bm::value_type(2,0.2) );
-    b.insert( bm::value_type(3,0.3) );
+    b.insert(bm::value_type(1, 0.1));
+    b.insert(bm::value_type(2, 0.2));
+    b.insert(bm::value_type(3, 0.3));
 
-    test_readable_property_map(b.left ,  1,0.1);
-    test_readable_property_map(b.right,0.1,  1);
+    test_readable_property_map(b.left, 1, 0.1);
+    test_readable_property_map(b.right, 0.1, 1);
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_property_map();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_range.cpp
+++ b/test/test_bimap_range.cpp
@@ -17,8 +17,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/config.hpp>
 
@@ -31,14 +31,17 @@
 #include <boost/bimap/multiset_of.hpp>
 #include <boost/bimap/support/lambda.hpp>
 
-
-template< class ForwardReadableRange, class UnaryFunctor >
-UnaryFunctor for_each(const ForwardReadableRange & r, UnaryFunctor func)
+template <typename ForwardReadableRange, typename UnaryFunctor>
+UnaryFunctor for_each(ForwardReadableRange const& r, UnaryFunctor func)
 {
     typedef typename 
     boost::range_const_iterator<ForwardReadableRange>::type const_iterator;
 
-    for(const_iterator i= boost::begin(r), iend= boost::end(r); i!=iend; ++i )
+    for (
+        const_iterator i = boost::begin(r), iend = boost::end(r);
+        i != iend;
+        ++i
+    )
     {
         func(*i);
     }
@@ -48,10 +51,10 @@ UnaryFunctor for_each(const ForwardReadableRange & r, UnaryFunctor func)
 
 struct do_something_with_a_pair
 {
-    template< class Pair >
-    void operator()(const Pair & p)
+    template <typename Pair>
+    void operator()(Pair const& p)
     {
-        BOOST_CHECK( p.first && p.second );
+        BOOST_TEST(p.first && p.second);
     }
 };
 
@@ -59,76 +62,83 @@ int test_bimap_range()
 {
     using namespace boost::bimaps;
 
-    typedef bimap< double, multiset_of<int> > bm_type;
-
+    typedef bimap<double,multiset_of<int> > bm_type;
 
     bm_type bm;
-    bm.insert( bm_type::value_type(1.1 , 1) );
-    bm.insert( bm_type::value_type(2.2 , 2) );
-    bm.insert( bm_type::value_type(3.3 , 3) );
-    bm.insert( bm_type::value_type(4.4 , 4) );
 
-
-    for_each( bm.left.range( 1.0 < _key, _key < 5.0 ),
-              do_something_with_a_pair() );
-
-    for_each( bm.right.range( unbounded, _key <= 2 ),
-              do_something_with_a_pair() );
-
+    bm.insert(bm_type::value_type(1.1, 1));
+    bm.insert(bm_type::value_type(2.2, 2));
+    bm.insert(bm_type::value_type(3.3, 3));
+    bm.insert(bm_type::value_type(4.4, 4));
+    for_each(
+        bm.left.range(1.0 < _key, _key < 5.0)
+      , do_something_with_a_pair()
+    );
+    for_each(
+        bm.right.range(unbounded, _key <= 2)
+      , do_something_with_a_pair()
+    );
 
     // left range
     {
-
-    bm_type::left_range_type r = bm.left.range( 2.0 < _key, _key < 4.0 );
-    BOOST_CHECK( ! boost::empty(r) );
-    BOOST_CHECK( boost::begin(r) == bm.left.upper_bound(2.0) );
-    BOOST_CHECK( boost::end(r)   == bm.left.lower_bound(4.0) );
-
+        bm_type::left_range_type r = bm.left.range(2.0 < _key, _key < 4.0);
+        BOOST_TEST(!boost::empty(r));
+        BOOST_TEST(boost::begin(r) == bm.left.upper_bound(2.0));
+        BOOST_TEST(boost::end(r) == bm.left.lower_bound(4.0));
     }
 
     // right range
     {
-
-    bm_type::right_range_type r = bm.right.range( 2 <= _key, _key <= 3 );
-    BOOST_CHECK( ! boost::empty(r) );
-    BOOST_CHECK( boost::begin(r) == bm.right.lower_bound(2) );
-    BOOST_CHECK( boost::end(r)   == bm.right.upper_bound(3) );
-
+        bm_type::right_range_type r = bm.right.range(2 <= _key, _key <= 3);
+        BOOST_TEST(!boost::empty(r));
+        BOOST_TEST(boost::begin(r) == bm.right.lower_bound(2));
+        BOOST_TEST(boost::end(r) == bm.right.upper_bound(3));
     }
 
     // const range from range
     {
-
-    bm_type:: left_const_range_type lr = bm. left.range( unbounded, _key < 4.0 );
-    bm_type::right_const_range_type rr = bm.right.range( 2 < _key ,  unbounded );
-
+        bm_type::left_const_range_type lr = bm.left.range(
+            unbounded
+          , _key < 4.0
+        );
+        bm_type::right_const_range_type rr = bm.right.range(
+            2 < _key
+          , unbounded
+        );
+        BOOST_TEST(!boost::empty(lr));
+        BOOST_TEST(boost::end(lr) == bm.left.lower_bound(4.0));
+        BOOST_TEST(!boost::empty(rr));
+        BOOST_TEST(boost::begin(rr) == bm.right.lower_bound(3));
     }
 
-    const bm_type & cbm = bm;
+    bm_type const& cbm = bm;
 
     // left const range
     {
-    bm_type:: left_const_range_type r = cbm.left.range( unbounded, unbounded );
-    BOOST_CHECK( ! boost::empty(r) );
-    BOOST_CHECK( boost::begin(r) == cbm.left.begin() );
-
+        bm_type::left_const_range_type r = cbm.left.range(
+            unbounded
+          , unbounded
+        );
+        BOOST_TEST(!boost::empty(r));
+        BOOST_TEST(boost::begin(r) == cbm.left.begin());
     }
 
     // right const range
     {
-
-    bm_type::right_const_range_type r = cbm.right.range( 1 < _key, _key < 1 );
-    BOOST_CHECK( boost::empty(r) );
-
+        bm_type::right_const_range_type r = cbm.right.range(
+            1 < _key
+          , _key < 1
+        );
+        BOOST_TEST(boost::empty(r));
     }
 
     return 0;
 }
 //]
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_range();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_sequenced.cpp
+++ b/test/test_bimap_sequenced.cpp
@@ -19,16 +19,12 @@
 
 #define BOOST_BIMAP_DISABLE_SERIALIZATION
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
-
 // std
 #include <set>
 #include <map>
 #include <algorithm>
 #include <string>
 #include <functional>
-
 
 // Set type specifications
 #include <boost/bimap/list_of.hpp>
@@ -38,56 +34,53 @@
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/support/lambda.hpp>
 
-#include <libs/bimap/test/test_bimap.hpp>
+#include "test_bimap.hpp"
 
-struct  left_tag {};
+struct left_tag {};
 struct right_tag {};
 
-
-template< class Container, class Data >
-void test_list_operations(Container & b, Container& c, const Data & d)
+template <typename Container, typename Data>
+void test_list_operations(Container& b, Container& c, Data const& d)
 {
-    c.clear() ;
+    c.clear();
     c.assign(d.begin(),d.end());
-        
-    BOOST_CHECK( std::equal( c.begin(), c.end(), d.begin() ) );
+    BOOST_TEST(std::equal(c.begin(), c.end(), d.begin()));
+
     c.reverse();
-    BOOST_CHECK( std::equal( c.begin(), c.end(), d.rbegin() ) );
+    BOOST_TEST(std::equal(c.begin(), c.end(), d.rbegin()));
 
     c.sort();
-    BOOST_CHECK( std::equal( c.begin(), c.end(), d.begin() ) );
+    BOOST_TEST(std::equal(c.begin(), c.end(), d.begin()));
 
-    c.push_front( *d.begin() );
-    BOOST_CHECK( c.size() == d.size()+1 );
+    c.push_front(*d.begin());
+    BOOST_TEST(c.size() == d.size() + 1);
+
     c.unique();
-    BOOST_CHECK( c.size() == d.size() );
- 
-    c.relocate( c.begin(), ++c.begin() );
-    c.relocate( c.end(), c.begin(), ++c.begin() );
-        
+    BOOST_TEST(c.size() == d.size());
+
+    c.relocate(c.begin(), ++c.begin());
+    c.relocate(c.end(), c.begin(), ++c.begin());
+
     b.clear();
     c.clear();
-    
-    c.assign(d.begin(),d.end());
-    b.splice(b.begin(),c);
 
-    BOOST_CHECK( c.size() == 0 );
-    BOOST_CHECK( b.size() == d.size() );
+    c.assign(d.begin(), d.end());
+    b.splice(b.begin(), c);
+    BOOST_TEST(c.size() == 0);
+    BOOST_TEST(b.size() == d.size());
 
-    c.splice(c.begin(),b,++b.begin());
+    c.splice(c.begin(), b, ++b.begin());
+    BOOST_TEST(c.size() == 1);
 
-    BOOST_CHECK( c.size() == 1 );
+    c.splice(c.begin(), b, b.begin(), b.end());
+    BOOST_TEST(b.size() == 0);
 
-    c.splice(c.begin(),b,b.begin(),b.end());
-
-    BOOST_CHECK( b.size() == 0 );
-
-    b.assign(d.begin(),d.end());
-    c.assign(d.begin(),d.end());
+    b.assign(d.begin(), d.end());
+    c.assign(d.begin(), d.end());
     b.sort();
     c.sort();
     b.merge(c);
-    BOOST_CHECK( b.size() == 2*d.size() );
+    BOOST_TEST(b.size() == 2 * d.size());
  
     b.unique();
 }
@@ -97,129 +90,131 @@ void test_bimap()
     using namespace boost::bimaps;
 
     typedef std::map<std::string,long> left_data_type;
+
     left_data_type left_data;
-    left_data.insert( left_data_type::value_type("1",1) );
-    left_data.insert( left_data_type::value_type("2",2) );
-    left_data.insert( left_data_type::value_type("3",3) );
-    left_data.insert( left_data_type::value_type("4",4) );
+
+    left_data.insert(left_data_type::value_type("1", 1));
+    left_data.insert(left_data_type::value_type("2", 2));
+    left_data.insert(left_data_type::value_type("3", 3));
+    left_data.insert(left_data_type::value_type("4", 4));
 
     typedef std::map<long,std::string> right_data_type;
-    right_data_type right_data;
-    right_data.insert( right_data_type::value_type(1,"1") );
-    right_data.insert( right_data_type::value_type(2,"2") );
-    right_data.insert( right_data_type::value_type(3,"3") );
-    right_data.insert( right_data_type::value_type(4,"4") );
 
+    right_data_type right_data;
+
+    right_data.insert(right_data_type::value_type(1, "1"));
+    right_data.insert(right_data_type::value_type(2, "2"));
+    right_data.insert(right_data_type::value_type(3, "3"));
+    right_data.insert(right_data_type::value_type(4, "4"));
 
     //--------------------------------------------------------------------
     {
-        typedef bimap<
-            list_of< std::string >, vector_of< long >
-            
-        > bm_type;
+        typedef bimap<list_of<std::string>,vector_of<long> > bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type("1",1) );
-        data.insert( bm_type::value_type("2",2) );
-        data.insert( bm_type::value_type("3",3) );
-        data.insert( bm_type::value_type("4",4) );
+        std::set<bm_type::value_type> data;
+
+        data.insert(bm_type::value_type("1", 1));
+        data.insert(bm_type::value_type("2", 2));
+        data.insert(bm_type::value_type("3", 3));
+        data.insert(bm_type::value_type("4", 4));
 
         bm_type b;
 
         test_bimap_init_copy_swap<bm_type>(data) ;
-        test_sequence_container(b,data);
-        test_sequence_container(b.left , left_data);
-        test_vector_container(b.right,right_data);
+        test_sequence_container(b, data);
+        test_sequence_container(b.left, left_data);
+        test_vector_container(b.right, right_data);
 
-        test_mapped_container(b.left );
+        test_mapped_container(b.left);
         test_mapped_container(b.right);
 
         bm_type c;
-        test_list_operations(b,c,data) ;
-        test_list_operations(b.left,c.left,left_data) ;
-        test_list_operations(b.right,c.right,right_data) ;
 
-        c.assign(data.begin(),data.end());
-        b.assign(data.begin(),data.end());
-        c.remove_if(_key<=bm_type::value_type("1",1));
+        test_list_operations(b, c, data);
+        test_list_operations(b.left, c.left, left_data);
+        test_list_operations(b.right, c.right, right_data);
+
+        c.assign(data.begin(), data.end());
+        b.assign(data.begin(), data.end());
+        c.remove_if(_key <= bm_type::value_type("1", 1));
         c.sort(std::less<bm_type::value_type>());
         b.sort(std::less<bm_type::value_type>());
-        c.merge(b,std::less<bm_type::value_type>());
+        c.merge(b, std::less<bm_type::value_type>());
         c.unique(std::equal_to<bm_type::value_type>());
-        
-        c.assign(data.begin(),data.end());
-        b.assign(data.begin(),data.end());
+
+        c.assign(data.begin(), data.end());
+        b.assign(data.begin(), data.end());
         c.left.remove_if(_key<="1");
         c.left.sort(std::less<std::string>());
         b.left.sort(std::less<std::string>());
-        c.left.merge(b.left,std::less<std::string>());
+        c.left.merge(b.left, std::less<std::string>());
         c.left.unique(std::equal_to<std::string>());
-        
-        c.assign(data.begin(),data.end());
-        b.assign(data.begin(),data.end());
-        c.right.remove_if(_key<=1);
+
+        c.assign(data.begin(), data.end());
+        b.assign(data.begin(), data.end());
+        c.right.remove_if(_key <= 1);
         c.right.sort(std::less<long>());
         b.right.sort(std::less<long>());
-        c.right.merge(b.right,std::less<long>());
+        c.right.merge(b.right, std::less<long>());
         c.right.unique(std::equal_to<long>());
 
-        c.assign(data.begin(),data.end());
+        c.assign(data.begin(), data.end());
         c.right[0].first = -1;
         c.right.at(0).second = "[1]";
     }
     //--------------------------------------------------------------------
 
-    
     //--------------------------------------------------------------------
     {
-        typedef bimap
-        <
-            vector_of<std::string>, list_of<long>,
-            vector_of_relation
-
+        typedef bimap<
+            vector_of<std::string>
+          , list_of<long>
+          , vector_of_relation
         > bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type("1",1) );
-        data.insert( bm_type::value_type("2",2) );
-        data.insert( bm_type::value_type("3",3) );
-        data.insert( bm_type::value_type("4",4) );
-        
+        std::set<bm_type::value_type> data;
+
+        data.insert(bm_type::value_type("1", 1));
+        data.insert(bm_type::value_type("2", 2));
+        data.insert(bm_type::value_type("3", 3));
+        data.insert(bm_type::value_type("4", 4));
+
         bm_type b;
-        
-        test_bimap_init_copy_swap<bm_type>(data) ;
-        test_vector_container(b,data) ;
-        
+
+        test_bimap_init_copy_swap<bm_type>(data);
+        test_vector_container(b, data);
+
         bm_type c;
-        test_list_operations(b,c,data) ;
-        test_list_operations(b.left,c.left,left_data) ;
-        test_list_operations(b.right,c.right,right_data) ;
-        
-        c.assign(data.begin(),data.end());
-        b.assign(data.begin(),data.end());
-        c.remove_if(_key<=bm_type::value_type("1",1));
+
+        test_list_operations(b, c, data);
+        test_list_operations(b.left, c.left, left_data);
+        test_list_operations(b.right, c.right, right_data);
+
+        c.assign(data.begin(), data.end());
+        b.assign(data.begin(), data.end());
+        c.remove_if(_key <= bm_type::value_type("1", 1));
         c.sort(std::less<bm_type::value_type>());
         b.sort(std::less<bm_type::value_type>());
-        c.merge(b,std::less<bm_type::value_type>());
+        c.merge(b, std::less<bm_type::value_type>());
         c.unique(std::equal_to<bm_type::value_type>());
-        
-        c.assign(data.begin(),data.end());
-        b.assign(data.begin(),data.end());
-        c.left.remove_if(_key<="1");
+
+        c.assign(data.begin(), data.end());
+        b.assign(data.begin(), data.end());
+        c.left.remove_if(_key <= "1");
         c.left.sort(std::less<std::string>());
         b.left.sort(std::less<std::string>());
-        c.left.merge(b.left,std::less<std::string>());
+        c.left.merge(b.left, std::less<std::string>());
         c.left.unique(std::equal_to<std::string>());
-        
-        c.assign(data.begin(),data.end());
-        b.assign(data.begin(),data.end());
+
+        c.assign(data.begin(), data.end());
+        b.assign(data.begin(), data.end());
         c.right.remove_if(_key<=1);
         c.right.sort(std::less<long>());
         b.right.sort(std::less<long>());
-        c.right.merge(b.right,std::less<long>());
+        c.right.merge(b.right, std::less<long>());
         c.right.unique(std::equal_to<long>());
-        
-        c.assign(data.begin(),data.end());
+
+        c.assign(data.begin(), data.end());
         c[0].left = "(1)";
         c.at(0).right = -1;
         c.left[0].first = "[1]";
@@ -227,53 +222,50 @@ void test_bimap()
     }
     //--------------------------------------------------------------------
 
-    
     //--------------------------------------------------------------------
     {
-        typedef bimap
-        <
-            vector_of<std::string>, list_of<long>,
-            list_of_relation
-
+        typedef bimap<
+            vector_of<std::string>
+          , list_of<long>
+          , list_of_relation
         > bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type("1",1) );
-        data.insert( bm_type::value_type("2",2) );
-        data.insert( bm_type::value_type("3",3) );
-        data.insert( bm_type::value_type("4",4) );
-        
-        bm_type b;
-        
-        test_bimap_init_copy_swap<bm_type>(data) ;
-        test_sequence_container(b,data) ;
-        
-        bm_type c;
-        test_list_operations(b,c,data) ;
-        test_list_operations(b.left,c.left,left_data) ;
-        test_list_operations(b.right,c.right,right_data) ;
+        std::set<bm_type::value_type> data;
 
-        
-        c.assign(data.begin(),data.end());
-        b.assign(data.begin(),data.end());
-        c.remove_if(_key<=bm_type::value_type("1",1));
+        data.insert(bm_type::value_type("1", 1));
+        data.insert(bm_type::value_type("2", 2));
+        data.insert(bm_type::value_type("3", 3));
+        data.insert(bm_type::value_type("4", 4));
+
+        bm_type b;
+
+        test_bimap_init_copy_swap<bm_type>(data);
+        test_sequence_container(b, data);
+
+        bm_type c;
+
+        test_list_operations(b, c, data);
+        test_list_operations(b.left, c.left, left_data);
+        test_list_operations(b.right, c.right, right_data);
+
+        c.assign(data.begin(), data.end());
+        b.assign(data.begin(), data.end());
+        c.remove_if(_key <= bm_type::value_type("1", 1));
         c.sort(std::less<bm_type::value_type>());
         b.sort(std::less<bm_type::value_type>());
-        c.merge(b,std::less<bm_type::value_type>());
+        c.merge(b, std::less<bm_type::value_type>());
         c.unique(std::equal_to<bm_type::value_type>());
-        
-        c.assign(data.begin(),data.end());
+
+        c.assign(data.begin(), data.end());
         c.left[0].first = "[1]";
         c.left.at(0).second = -1;
     }
     //--------------------------------------------------------------------
-
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_serialization.cpp
+++ b/test/test_bimap_serialization.cpp
@@ -26,8 +26,8 @@
 #include <sstream>
 #include <algorithm>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost
 #include <boost/archive/text_oarchive.hpp>
@@ -37,22 +37,19 @@
 #include <boost/bimap/bimap.hpp>
 
 
-template< class Bimap, class Archive >
-void save_bimap(const Bimap & b, Archive & ar)
+template <typename Bimap, typename Archive>
+void save_bimap(Bimap const& b, Archive& ar)
 {
     using namespace boost::bimaps;
 
     ar << b;
 
-    const typename Bimap::left_const_iterator left_iter = b.left.begin();
+    typename Bimap::left_const_iterator const left_iter = b.left.begin();
     ar << left_iter;
 
-    const typename Bimap::const_iterator iter = ++b.begin();
+    typename Bimap::const_iterator const iter = ++b.begin();
     ar << iter;
 }
-
-
-
 
 void test_bimap_serialization()
 {
@@ -60,11 +57,11 @@ void test_bimap_serialization()
 
     typedef bimap<int,double> bm;
 
-    std::set< bm::value_type > data;
-    data.insert( bm::value_type(1,0.1) );
-    data.insert( bm::value_type(2,0.2) );
-    data.insert( bm::value_type(3,0.3) );
-    data.insert( bm::value_type(4,0.4) );
+    std::set<bm::value_type> data;
+    data.insert(bm::value_type(1, 0.1));
+    data.insert(bm::value_type(2, 0.2));
+    data.insert(bm::value_type(3, 0.3));
+    data.insert(bm::value_type(4, 0.4));
 
     std::ostringstream oss;
 
@@ -72,7 +69,7 @@ void test_bimap_serialization()
     {
         bm b;
 
-        b.insert(data.begin(),data.end());
+        b.insert(data.begin(), data.end());
 
         boost::archive::text_oarchive oa(oss);
 
@@ -88,27 +85,25 @@ void test_bimap_serialization()
 
         ia >> b;
 
-        BOOST_CHECK( std::equal( b.begin(), b.end(), data.begin() ) );
+        BOOST_TEST(std::equal(b.begin(), b.end(), data.begin()));
 
         bm::left_const_iterator left_iter;
 
         ia >> left_iter;
 
-        BOOST_CHECK( left_iter == b.left.begin() );
+        BOOST_TEST(left_iter == b.left.begin());
 
         bm::const_iterator iter;
 
         ia >> iter;
 
-        BOOST_CHECK( iter == ++b.begin() );
+        BOOST_TEST(iter == ++b.begin());
     }
-
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_serialization();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_set_of.cpp
+++ b/test/test_bimap_set_of.cpp
@@ -17,16 +17,16 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/bimap/set_of.hpp>
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
-    typedef boost::bimaps::set_of<int>       set_type;
+    typedef boost::bimaps::set_of<int> set_type;
     typedef boost::bimaps::set_of_relation<> set_type_of_relation;
 
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_unconstrained.cpp
+++ b/test/test_bimap_unconstrained.cpp
@@ -17,13 +17,12 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.Bimap
 #include <boost/bimap/support/lambda.hpp>
 #include <boost/bimap/bimap.hpp>
-
 
 void test_bimap_unconstrained()
 {
@@ -31,79 +30,77 @@ void test_bimap_unconstrained()
 
     {
         typedef bimap<int,double,unconstrained_set_of_relation> bm;
+
         bm b;
-        b.left.insert( bm::left_value_type(2,34.4) );
-        b.right.insert( bm::right_value_type(2.2,3) );
+        b.left.insert(bm::left_value_type(2, 34.4));
+        b.right.insert(bm::right_value_type(2.2, 3));
     }
 
     {
         typedef bimap<int,unconstrained_set_of<double> > bm;
+
         bm b;
-        b.insert( bm::value_type(2,34.4) );
-        BOOST_CHECK( b.size() == 1 );
+        b.insert(bm::value_type(2, 34.4));
+
+        BOOST_TEST(b.size() == 1);
     }
 
     {
-        typedef bimap<unconstrained_set_of<int>, double > bm;
-        bm b;
-        b.right[2.4] = 34;
-        BOOST_CHECK( b.right.size() == 1 );
-    }
+        typedef bimap<unconstrained_set_of<int>,double> bm;
 
-    {
-        typedef bimap<unconstrained_set_of<int>, double, right_based > bm;
         bm b;
         b.right[2.4] = 34;
-        BOOST_CHECK( b.right.size() == 1 );
+        BOOST_TEST(b.right.size() == 1);
     }
 
     {
-        typedef bimap
-        <
-            int,
-            unconstrained_set_of<double>,
-            unconstrained_set_of_relation
+        typedef bimap<unconstrained_set_of<int>,double,right_based> bm;
 
+        bm b;
+        b.right[2.4] = 34;
+        BOOST_TEST(b.right.size() == 1);
+    }
+
+    {
+        typedef bimap<
+            int
+          , unconstrained_set_of<double>
+          , unconstrained_set_of_relation
         > bm;
 
         bm b;
         b.left[2] = 34.4;
-        BOOST_CHECK( b.left.size() == 1 );
+        BOOST_TEST(b.left.size() == 1);
     }
 
     {
-        typedef bimap
-        <
-            unconstrained_set_of<int>,
-            double,
-            unconstrained_set_of_relation
-
+        typedef bimap<
+            unconstrained_set_of<int>
+          , double
+          , unconstrained_set_of_relation
         > bm;
 
         bm b;
         b.right[2.4] = 34;
-        BOOST_CHECK( b.right.size() == 1 );
+        BOOST_TEST(b.right.size() == 1);
     }
 
     {
-        typedef bimap
-        <
-            unconstrained_set_of<int>,
-            unconstrained_set_of<double>,
-            set_of_relation<>
-
+        typedef bimap<
+            unconstrained_set_of<int>
+          , unconstrained_set_of<double>
+          , set_of_relation<>
         > bm;
 
         bm b;
-        b.insert( bm::value_type(1,2.3) );
-        BOOST_CHECK( b.size() == 1 );
+        b.insert(bm::value_type(1, 2.3));
+        BOOST_TEST(b.size() == 1);
     }
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap_unconstrained();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_unordered.cpp
+++ b/test/test_bimap_unordered.cpp
@@ -19,9 +19,6 @@
 
 #define BOOST_BIMAP_DISABLE_SERIALIZATION
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
-
 // std
 #include <set>
 #include <map>
@@ -35,133 +32,126 @@
 // bimap container
 #include <boost/bimap/bimap.hpp>
 
-#include <libs/bimap/test/test_bimap.hpp>
+#include "test_bimap.hpp"
 
-struct  left_tag {};
+struct left_tag {};
 struct right_tag {};
 
 void test_bimap()
 {
     using namespace boost::bimaps;
 
-
     typedef std::map<char,std::string> left_data_type;
     left_data_type left_data;
-    left_data.insert( left_data_type::value_type('a',"a") );
-    left_data.insert( left_data_type::value_type('b',"b") );
-    left_data.insert( left_data_type::value_type('c',"c") );
-    left_data.insert( left_data_type::value_type('d',"e") );
+    left_data.insert(left_data_type::value_type('a', "a"));
+    left_data.insert(left_data_type::value_type('b', "b"));
+    left_data.insert(left_data_type::value_type('c', "c"));
+    left_data.insert(left_data_type::value_type('d', "e"));
 
     typedef std::map<std::string,char> right_data_type;
     right_data_type right_data;
-    right_data.insert( right_data_type::value_type("a",'a') );
-    right_data.insert( right_data_type::value_type("b",'b') );
-    right_data.insert( right_data_type::value_type("c",'c') );
-    right_data.insert( right_data_type::value_type("d",'e') );
-
-
+    right_data.insert(right_data_type::value_type("a", 'a'));
+    right_data.insert(right_data_type::value_type("b", 'b'));
+    right_data.insert(right_data_type::value_type("c", 'c'));
+    right_data.insert(right_data_type::value_type("d", 'e'));
 
     //--------------------------------------------------------------------
     {
         typedef bimap<
-            unordered_set_of<char>, unordered_multiset_of<std::string>
-
+            unordered_set_of<char>
+          , unordered_multiset_of<std::string>
         > bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type('a',"a") );
-        data.insert( bm_type::value_type('b',"b") );
-        data.insert( bm_type::value_type('c',"c") );
-        data.insert( bm_type::value_type('d',"d") );
+        std::set<bm_type::value_type> data;
+        data.insert(bm_type::value_type('a', "a"));
+        data.insert(bm_type::value_type('b', "b"));
+        data.insert(bm_type::value_type('c', "c"));
+        data.insert(bm_type::value_type('d', "d"));
 
         bm_type bm;
 
         test_unordered_set_unordered_multiset_bimap(
-            bm,data,left_data,right_data
+            bm
+          , data
+          , left_data
+          , right_data
         );
     }
     //--------------------------------------------------------------------
-
 
     //--------------------------------------------------------------------
     {
         typedef bimap<
-                 unordered_set_of< tagged< char       , left_tag  > >,
-            unordered_multiset_of< tagged< std::string, right_tag > >
-
+            unordered_set_of<tagged<char,left_tag> >
+          , unordered_multiset_of<tagged<std::string,right_tag> >
         > bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type('a',"a") );
-        data.insert( bm_type::value_type('b',"b") );
-        data.insert( bm_type::value_type('c',"c") );
-        data.insert( bm_type::value_type('d',"d") );
+        std::set<bm_type::value_type> data;
+        data.insert(bm_type::value_type('a', "a"));
+        data.insert(bm_type::value_type('b', "b"));
+        data.insert(bm_type::value_type('c', "c"));
+        data.insert(bm_type::value_type('d', "d"));
 
         bm_type bm;
 
         test_unordered_set_unordered_multiset_bimap(
-            bm,data,left_data,right_data
+            bm
+          , data
+          , left_data
+          , right_data
         );
-        test_tagged_bimap<left_tag,right_tag>(bm,data);
+        test_tagged_bimap<left_tag,right_tag>(bm, data);
     }
     //--------------------------------------------------------------------
 
-
     //--------------------------------------------------------------------
     {
-        typedef bimap
-        <
-            set_of< char, std::greater<char> >,
-            unordered_multiset_of<std::string>,
-            unordered_set_of_relation<>
-
+        typedef bimap<
+            set_of<char,std::greater<char> >
+          , unordered_multiset_of<std::string>
+          , unordered_set_of_relation<>
         > bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type('a',"a") );
-        data.insert( bm_type::value_type('b',"b") );
-        data.insert( bm_type::value_type('c',"c") );
-        data.insert( bm_type::value_type('d',"d") );
+        std::set<bm_type::value_type> data;
+        data.insert(bm_type::value_type('a', "a"));
+        data.insert(bm_type::value_type('b', "b"));
+        data.insert(bm_type::value_type('c', "c"));
+        data.insert(bm_type::value_type('d', "d"));
 
         bm_type bm;
 
-        test_basic_bimap(bm,data,left_data,right_data);
-        test_associative_container(bm,data);
-        test_simple_unordered_associative_container(bm,data);
+        test_basic_bimap(bm, data, left_data, right_data);
+        test_associative_container(bm, data);
+        test_simple_unordered_associative_container(bm, data);
     }
     //--------------------------------------------------------------------
 
-
     //--------------------------------------------------------------------
     {
-                typedef bimap
-        <
-            unordered_multiset_of< char >,
-            unordered_multiset_of< std::string >,
-            unordered_multiset_of_relation<>
-
+        typedef bimap<
+            unordered_multiset_of<char>
+          , unordered_multiset_of<std::string>
+          , unordered_multiset_of_relation<>
         > bm_type;
 
-        std::set< bm_type::value_type > data;
-        data.insert( bm_type::value_type('a',"a") );
-        data.insert( bm_type::value_type('b',"b") );
-        data.insert( bm_type::value_type('c',"c") );
-        data.insert( bm_type::value_type('d',"d") );
+        std::set<bm_type::value_type> data;
+        data.insert(bm_type::value_type('a', "a"));
+        data.insert(bm_type::value_type('b', "b"));
+        data.insert(bm_type::value_type('c', "c"));
+        data.insert(bm_type::value_type('d', "d"));
 
         bm_type bm;
 
-        test_basic_bimap(bm,data,left_data,right_data);
-        test_associative_container(bm,data);
-        test_simple_unordered_associative_container(bm,data);
-
+        test_basic_bimap(bm, data, left_data, right_data);
+        test_associative_container(bm, data);
+        test_simple_unordered_associative_container(bm, data);
     }
     //--------------------------------------------------------------------
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_bimap();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_unordered_multiset_of.cpp
+++ b/test/test_bimap_unordered_multiset_of.cpp
@@ -17,18 +17,18 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/bimap/unordered_multiset_of.hpp>
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     typedef boost::bimaps::unordered_multiset_of<int> set_type;
 
     typedef boost::bimaps::
         unordered_multiset_of_relation<> set_type_of_relation;
 
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_unordered_set_of.cpp
+++ b/test/test_bimap_unordered_set_of.cpp
@@ -17,16 +17,16 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/bimap/unordered_set_of.hpp>
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
-    typedef boost::bimaps::unordered_set_of<int>       set_type;
+    typedef boost::bimaps::unordered_set_of<int> set_type;
     typedef boost::bimaps::unordered_set_of_relation<> set_type_of_relation;
 
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_bimap_vector_of.cpp
+++ b/test/test_bimap_vector_of.cpp
@@ -17,16 +17,16 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/bimap/vector_of.hpp>
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
-    typedef boost::bimaps::vector_of<int>     set_type;
+    typedef boost::bimaps::vector_of<int> set_type;
     typedef boost::bimaps::vector_of_relation set_type_of_relation;
 
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_mutant.cpp
+++ b/test/test_mutant.cpp
@@ -17,8 +17,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.MPL
 #include <boost/mpl/list.hpp>
@@ -31,11 +31,11 @@ using namespace boost::bimaps::relation::detail;
 
 // The mutant idiom is standard if only POD types are used.
 
-typedef double  type_a;
-typedef int     type_b;
+typedef double type_a;
+typedef int type_b;
 
-const type_a value_a = 1.4;
-const type_b value_b = 3;
+type_a const value_a = 1.4;
+type_b const value_b = 3;
 
 struct Data
 {
@@ -47,6 +47,7 @@ struct StdPairView
 {
     typedef type_a first_type;
     typedef type_b second_type;
+
     type_a first;
     type_b second;
 };
@@ -55,49 +56,51 @@ struct ReverseStdPairView
 {
     typedef type_a second_type;
     typedef type_b first_type;
+
     type_a second;
     type_b first;
 };
 
-
 struct MutantData
 {
-    typedef boost::mpl::list< StdPairView, ReverseStdPairView > mutant_views;
+    typedef boost::mpl::list<StdPairView,ReverseStdPairView> mutant_views;
 
-    MutantData(type_a ap, type_b bp) : a(ap), b(bp) {}
+    MutantData(type_a ap, type_b bp) : a(ap), b(bp)
+    {
+    }
+
     type_a a;
     type_b b;
 };
 
-
 void test_mutant_basic()
 {
-
     // mutant test
     {
-        MutantData m(value_a,value_b);
+        MutantData m(value_a, value_b);
 
-        BOOST_CHECK( sizeof( MutantData ) == sizeof( StdPairView ) );
+        BOOST_TEST(sizeof(MutantData) == sizeof(StdPairView));
 
-        BOOST_CHECK( mutate<StdPairView>(m).first  == value_a );
-        BOOST_CHECK( mutate<StdPairView>(m).second == value_b );
-        BOOST_CHECK( mutate<ReverseStdPairView>(m).first  == value_b );
-        BOOST_CHECK( mutate<ReverseStdPairView>(m).second == value_a );
+        BOOST_TEST(mutate<StdPairView>(m).first == value_a);
+        BOOST_TEST(mutate<StdPairView>(m).second == value_b);
+        BOOST_TEST(mutate<ReverseStdPairView>(m).first == value_b);
+        BOOST_TEST(mutate<ReverseStdPairView>(m).second == value_a);
 
-        ReverseStdPairView & rpair = mutate<ReverseStdPairView>(m);
+        ReverseStdPairView& rpair = mutate<ReverseStdPairView>(m);
         rpair.first = value_b;
         rpair.second = value_a;
 
-        BOOST_CHECK( mutate<StdPairView>(m).first  == value_a );
-        BOOST_CHECK( mutate<StdPairView>(m).second == value_b );
+        BOOST_TEST(mutate<StdPairView>(m).first == value_a);
+        BOOST_TEST(mutate<StdPairView>(m).second == value_b);
 
-        BOOST_CHECK( &mutate<StdPairView>(m).first  == &m.a );
-        BOOST_CHECK( &mutate<StdPairView>(m).second == &m.b );
+        BOOST_TEST(&mutate<StdPairView>(m).first == &m.a);
+        BOOST_TEST(&mutate<StdPairView>(m).second == &m.b);
     }
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_mutant_basic();
-    return 0;
+    return boost::report_errors();
 }
+

--- a/test/test_mutant_relation.cpp
+++ b/test/test_mutant_relation.cpp
@@ -20,8 +20,8 @@
 // std
 #include <string>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.MPL
 #include <boost/mpl/assert.hpp>
@@ -44,66 +44,87 @@
 // Bimap Test Utilities
 #include "test_relation.hpp"
 
-BOOST_BIMAP_TEST_STATIC_FUNCTION( untagged_static_test )
+BOOST_BIMAP_TEST_STATIC_FUNCTION(untagged_static_test)
 {
     using namespace boost::bimaps::relation::member_at;
     using namespace boost::bimaps::relation;
     using namespace boost::bimaps::tags;
 
-    struct left_data  {};
+    struct left_data {};
     struct right_data {};
 
-    typedef mutant_relation< left_data, right_data > rel;
+    typedef mutant_relation<left_data,right_data> rel;
 
-    BOOST_BIMAP_CHECK_METADATA(rel,left_value_type ,left_data);
-    BOOST_BIMAP_CHECK_METADATA(rel,right_value_type,right_data);
+    BOOST_BIMAP_CHECK_METADATA(rel, left_value_type ,left_data);
+    BOOST_BIMAP_CHECK_METADATA(rel, right_value_type, right_data);
 
-    BOOST_BIMAP_CHECK_METADATA(rel,left_tag ,left );
-    BOOST_BIMAP_CHECK_METADATA(rel,right_tag,right);
+    BOOST_BIMAP_CHECK_METADATA(rel, left_tag, left);
+    BOOST_BIMAP_CHECK_METADATA(rel, right_tag, right);
 
-    typedef tagged<left_data ,left > desired_tagged_left_type;
-    BOOST_BIMAP_CHECK_METADATA(rel,tagged_left_type,desired_tagged_left_type);
+    typedef tagged<left_data,left> desired_tagged_left_type;
+    BOOST_BIMAP_CHECK_METADATA(
+        rel
+      , tagged_left_type
+      , desired_tagged_left_type
+    );
 
     typedef tagged<right_data,right> desired_tagged_right_type;
-    BOOST_BIMAP_CHECK_METADATA(rel,tagged_right_type,desired_tagged_right_type);
-
+    BOOST_BIMAP_CHECK_METADATA(
+        rel
+      , tagged_right_type
+      , desired_tagged_right_type
+    );
 }
 
-BOOST_BIMAP_TEST_STATIC_FUNCTION( tagged_static_test)
+BOOST_BIMAP_TEST_STATIC_FUNCTION(tagged_static_test)
 {
     using namespace boost::bimaps::relation::member_at;
     using namespace boost::bimaps::relation;
     using namespace boost::bimaps::tags;
 
-    struct left_data  {};
+    struct left_data {};
     struct right_data {};
 
-    struct left_tag   {};
-    struct right_tag  {};
+    struct left_tag {};
+    struct right_tag {};
 
     typedef mutant_relation<
-        tagged<left_data,left_tag>, tagged<right_data,right_tag> > rel;
+        tagged<left_data,left_tag>
+      , tagged<right_data,right_tag>
+    > rel;
 
-    BOOST_BIMAP_CHECK_METADATA(rel,left_value_type ,left_data);
-    BOOST_BIMAP_CHECK_METADATA(rel,right_value_type,right_data);
+    BOOST_BIMAP_CHECK_METADATA(rel, left_value_type, left_data);
+    BOOST_BIMAP_CHECK_METADATA(rel, right_value_type, right_data);
 
-    BOOST_BIMAP_CHECK_METADATA(rel,left_tag ,left_tag  );
-    BOOST_BIMAP_CHECK_METADATA(rel,right_tag,right_tag );
+    BOOST_BIMAP_CHECK_METADATA(rel, left_tag, left_tag);
+    BOOST_BIMAP_CHECK_METADATA(rel, right_tag, right_tag);
 
-    typedef tagged<left_data ,left_tag > desired_tagged_left_type;
-    BOOST_BIMAP_CHECK_METADATA(rel,tagged_left_type,desired_tagged_left_type);
+    typedef tagged<left_data,left_tag> desired_tagged_left_type;
+    BOOST_BIMAP_CHECK_METADATA(
+        rel
+      , tagged_left_type
+      , desired_tagged_left_type
+    );
 
     typedef tagged<right_data,right_tag> desired_tagged_right_type;
-    BOOST_BIMAP_CHECK_METADATA(rel,tagged_right_type,desired_tagged_right_type);
+    BOOST_BIMAP_CHECK_METADATA(
+        rel
+      , tagged_right_type
+      , desired_tagged_right_type
+    );
 }
 
 struct mutant_relation_builder
 {
-    template< class LeftType, class RightType >
+    template <typename LeftType, typename RightType>
     struct build
     {
-        typedef boost::bimaps::relation::
-            mutant_relation<LeftType,RightType,::boost::mpl::na,true> type;
+        typedef boost::bimaps::relation::mutant_relation<
+            LeftType
+          , RightType
+          , ::boost::mpl::na
+          , true
+        > type;
     };
 };
 
@@ -111,131 +132,161 @@ struct mutant_relation_builder
 
 class cc1
 {
-    public:
-    cc1(int s = 0) : a(s+100), b(s+101) {}
+ public:
+    cc1(int s = 0) : a(s + 100), b(s + 101)
+    {
+    }
+
     static int sd;
     int a;
-    const int b;
+    int const b;
 };
 
-bool operator==(const cc1 & da, const cc1 & db)
+bool operator==(cc1 const& da, cc1 const& db)
 {
-    return da.a == db.a && da.b == db.b; 
+    return (da.a == db.a) && (da.b == db.b); 
 }
 
 int cc1::sd = 102;
 
 class cc2_base
 {
-    public:
-    cc2_base(int s) : a(s+200) {}
+ public:
+    cc2_base(int s) : a(s + 200)
+    {
+    }
+
     int a;
 };
 
 class cc2 : public cc2_base
 {
-    public:
-    cc2(int s = 0) : cc2_base(s), b(s+201) {}
+ public:
+    cc2(int s = 0) : cc2_base(s), b(s + 201)
+    {
+    }
+
     int b;
 };
 
-bool operator==(const cc2 & da, const cc2 & db)
+bool operator==(cc2 const& da, cc2 const& db)
 {
-    return da.a == db.a && da.b == db.b; 
+    return (da.a == db.a) && (da.b == db.b); 
 }
 
 class cc3_base
 {
-    public:
-    cc3_base(int s = 0) : a(s+300) {}
-    const int a;
+ public:
+    cc3_base(int s = 0) : a(s + 300)
+    {
+    }
+
+    int const a;
 };
 
 class cc3 : virtual public cc3_base
 {
-   public:
-   cc3(int s = 0) : cc3_base(s), b(s+301) {}
-   int b;
+ public:
+    cc3(int s = 0) : cc3_base(s), b(s + 301)
+    {
+    }
+
+    int b;
 };
 
-bool operator==(const cc3 & da, const cc3 & db)
+bool operator==(cc3 const& da, cc3 const& db)
 {
-    return da.a == db.a && da.b == db.b; 
+    return (da.a == db.a) && (da.b == db.b); 
 }
 
 class cc4_base
 {
-    public:
-    cc4_base(int s) : a(s+400) {}
-    virtual ~cc4_base() {}
-    const int a;
+ public:
+    cc4_base(int s) : a(s + 400)
+    {
+    }
+
+    virtual ~cc4_base()
+    {
+    }
+
+    int const a;
 };
 
 class cc4 : public cc4_base
 {
-   public:
-   cc4(int s = 0) : cc4_base(s), b(s+401) {}
-   int b;
+ public:
+    cc4(int s = 0) : cc4_base(s), b(s + 401)
+    {
+    }
+
+    int b;
 };
 
-bool operator==(const cc4 & da, const cc4 & db)
+bool operator==(cc4 const& da, cc4 const& db)
 {
-    return da.a == db.a && da.b == db.b; 
+    return (da.a == db.a) && (da.b == db.b); 
 }
 
 class cc5 : public cc1, public cc3, public cc4
 {
-    public:
-    cc5(int s = 0) : cc1(s), cc3(s), cc4(s) {}
+ public:
+    cc5(int s = 0) : cc1(s), cc3(s), cc4(s)
+    {
+    }
 };
 
-bool operator==(const cc5 & da, const cc5 & db)
+bool operator==(cc5 const& da, cc5 const& db)
 {
-    return da.cc1::a == db.cc1::a && da.cc1::b == db.cc1::b &&
-           da.cc3::a == db.cc3::a && da.cc3::b == db.cc3::b &&
-           da.cc4::a == db.cc4::a && da.cc4::b == db.cc4::b;
+    return (da.cc1::a == db.cc1::a) && (da.cc1::b == db.cc1::b) && (
+        da.cc3::a == db.cc3::a
+    ) && (da.cc3::b == db.cc3::b) && (da.cc4::a == db.cc4::a) && (
+        da.cc4::b == db.cc4::b
+    );
 }
 
 class cc6
 {
-    public:
-    cc6(int s = 0) : a(s+600), b(a) {}
+ public:
+    cc6(int s = 0) : a(s + 600), b(a)
+    {
+    }
+
     int a;
-    int & b;
+    int& b;
 };
 
-bool operator==(const cc6 & da, const cc6 & db)
+bool operator==(cc6 const& da, cc6 const& db)
 {
-    return da.a == db.a && da.b == db.b;
+    return (da.a == db.a) && (da.b == db.b);
 }
 
 void test_mutant_relation()
 {
-    test_relation< mutant_relation_builder, char  , double >( 'l', 2.5 );
-    test_relation< mutant_relation_builder, double, char   >( 2.5, 'r' );
-
-    test_relation<mutant_relation_builder, int   , int    >(  1 ,   2 );
-
-    test_relation<mutant_relation_builder, std::string, int* >("left value",0);
-
-    test_relation<mutant_relation_builder, cc1, cc2>(0,0);
-    test_relation<mutant_relation_builder, cc2, cc3>(0,0);
-    test_relation<mutant_relation_builder, cc3, cc4>(0,0);
-    test_relation<mutant_relation_builder, cc4, cc5>(0,0);
+    test_relation<mutant_relation_builder,char,double>('l', 2.5);
+    test_relation<mutant_relation_builder,double,char>(2.5, 'r');
+    test_relation<mutant_relation_builder,int,int>(1, 2);
+    test_relation<mutant_relation_builder,std::string,int*>(
+        "left value"
+      , 0
+    );
+    test_relation<mutant_relation_builder,cc1,cc2>(0, 0);
+    test_relation<mutant_relation_builder,cc2,cc3>(0, 0);
+    test_relation<mutant_relation_builder,cc3,cc4>(0, 0);
+    test_relation<mutant_relation_builder,cc4,cc5>(0, 0);
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
-
     // Test metadata correctness with untagged relation version
-    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION( tagged_static_test   );
+    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION(tagged_static_test);
 
     // Test metadata correctness with tagged relation version
-    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION( untagged_static_test );
+    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION(untagged_static_test);
 
     // Test basic
     test_mutant_relation();
 
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_relation.hpp
+++ b/test/test_relation.hpp
@@ -15,8 +15,8 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // Boost.MPL
 #include <boost/mpl/assert.hpp>
@@ -35,91 +35,80 @@
 #include <boost/bimap/relation/support/member_with_tag.hpp>
 #include <boost/bimap/relation/support/is_tag_of_member_at.hpp>
 
-
-
-template< class Relation >
-void test_relation_with_default_tags(Relation & rel,
-    const typename Relation::left_value_type  & lv,
-    const typename Relation::right_value_type & rv)
+template <typename Relation>
+void
+    test_relation_with_default_tags(
+        Relation& rel
+      , BOOST_DEDUCED_TYPENAME Relation::left_value_type const& lv
+      , BOOST_DEDUCED_TYPENAME Relation::right_value_type const& rv
+    )
 {
-
     using namespace boost::bimaps::relation::support;
     using namespace boost::bimaps::relation;
     using namespace boost::bimaps::tags;
 
     // It must work with normal tags
 
-    BOOST_CHECK( pair_by<member_at::left >(rel).first  == lv );
-    BOOST_CHECK( pair_by<member_at::left >(rel).second == rv );
-
-    BOOST_CHECK( pair_by<member_at::right>(rel).first  == rv );
-    BOOST_CHECK( pair_by<member_at::right>(rel).second == lv );
-
-    BOOST_CHECK( get<member_at::left >(rel) == rel.left  );
-    BOOST_CHECK( get<member_at::right>(rel) == rel.right );
-
-    BOOST_CHECK(
-        get<member_at::left >(pair_by<member_at::left >(rel)) == rel.left
+    BOOST_TEST(pair_by<member_at::left>(rel).first == lv);
+    BOOST_TEST(pair_by<member_at::left>(rel).second == rv);
+    BOOST_TEST(pair_by<member_at::right>(rel).first == rv);
+    BOOST_TEST(pair_by<member_at::right>(rel).second == lv);
+    BOOST_TEST(get<member_at::left>(rel) == rel.left);
+    BOOST_TEST(get<member_at::right>(rel) == rel.right);
+    BOOST_TEST(
+        get<member_at::left>(pair_by<member_at::left>(rel)) == rel.left
     );
-
-    BOOST_CHECK(
-        get<member_at::right>(pair_by<member_at::left >(rel)) == rel.right
+    BOOST_TEST(
+        get<member_at::right>(pair_by<member_at::left>(rel)) == rel.right
     );
-
-    BOOST_CHECK(
-        get<member_at::left >(pair_by<member_at::right>(rel)) == rel.left
+    BOOST_TEST(
+        get<member_at::left>(pair_by<member_at::right>(rel)) == rel.left
     );
-
-    BOOST_CHECK(
+    BOOST_TEST(
         get<member_at::right>(pair_by<member_at::right>(rel)) == rel.right
     );
-
 }
 
-template< class Relation, class LeftTag, class RightTag >
-void test_relation_with_user_tags(Relation & rel,
-                   const typename Relation::left_value_type  & lv,
-                   const typename Relation::right_value_type & rv)
+template <typename Relation, typename LeftTag, typename RightTag>
+void
+    test_relation_with_user_tags(
+        Relation& rel
+      , BOOST_DEDUCED_TYPENAME Relation::left_value_type const& lv
+      , BOOST_DEDUCED_TYPENAME Relation::right_value_type const& rv
+    )
 {
-
     using namespace boost::bimaps::relation::support;
     using namespace boost::bimaps::relation;
     using namespace boost::bimaps::tags;
 
     // And with users ones
 
-    BOOST_CHECK( pair_by<LeftTag >(rel).first   == lv );
-    BOOST_CHECK( pair_by<LeftTag >(rel).second  == rv );
-
-    BOOST_CHECK( pair_by<RightTag>(rel).first   == rv );
-    BOOST_CHECK( pair_by<RightTag>(rel).second  == lv );
-
-    BOOST_CHECK( get<LeftTag >(rel) == rel.left  );
-    BOOST_CHECK( get<RightTag>(rel) == rel.right );
-
-    BOOST_CHECK( get<LeftTag >(pair_by<LeftTag >(rel)) == rel.left  );
-    BOOST_CHECK( get<RightTag>(pair_by<LeftTag >(rel)) == rel.right );
-
-    BOOST_CHECK( get<LeftTag >(pair_by<RightTag>(rel)) == rel.left  );
-    BOOST_CHECK( get<RightTag>(pair_by<RightTag>(rel)) == rel.right );
+    BOOST_TEST(pair_by<LeftTag>(rel).first == lv);
+    BOOST_TEST(pair_by<LeftTag>(rel).second == rv);
+    BOOST_TEST(pair_by<RightTag>(rel).first == rv);
+    BOOST_TEST(pair_by<RightTag>(rel).second == lv);
+    BOOST_TEST(get<LeftTag>(rel) == rel.left);
+    BOOST_TEST(get<RightTag>(rel) == rel.right);
+    BOOST_TEST(get<LeftTag>(pair_by<LeftTag>(rel)) == rel.left);
+    BOOST_TEST(get<RightTag>(pair_by<LeftTag>(rel)) == rel.right);
+    BOOST_TEST(get<LeftTag>(pair_by<RightTag>(rel)) == rel.left);
+    BOOST_TEST(get<RightTag>(pair_by<RightTag>(rel)) == rel.right);
 
     //----------------------------------------------------------------
 
-    BOOST_CHECK( rel.template get<LeftTag >() == rel.left  );
-    BOOST_CHECK( rel.template get<RightTag>() == rel.right );
-
-    BOOST_CHECK( pair_by<LeftTag >(rel).template get<LeftTag >()== rel.left );
-    BOOST_CHECK( pair_by<LeftTag >(rel).template get<RightTag>()== rel.right);
-
-    BOOST_CHECK( pair_by<RightTag>(rel).template get<LeftTag >()== rel.left );
-    BOOST_CHECK( pair_by<RightTag>(rel).template get<RightTag>()== rel.right);
+    BOOST_TEST(rel.template get<LeftTag>() == rel.left);
+    BOOST_TEST(rel.template get<RightTag>() == rel.right);
+    BOOST_TEST(pair_by<LeftTag>(rel).template get<LeftTag>() == rel.left);
+    BOOST_TEST(pair_by<LeftTag>(rel).template get<RightTag>() == rel.right);
+    BOOST_TEST(pair_by<RightTag>(rel).template get<LeftTag>() == rel.left);
+    BOOST_TEST(pair_by<RightTag>(rel).template get<RightTag>() == rel.right);
 }
 
-struct  left_user_tag {};
+struct left_user_tag {};
 struct right_user_tag {};
 
-template< class RelationBuilder, class LeftData, class RightData >
-void test_relation(const LeftData & lv, const RightData & rv)
+template <typename RelationBuilder, typename LeftData, typename RightData>
+void test_relation(LeftData const& lv, RightData const& rv)
 {
     using namespace boost::bimaps::relation::support;
     using namespace boost::bimaps::relation;
@@ -127,65 +116,63 @@ void test_relation(const LeftData & lv, const RightData & rv)
 
     // Untagged test
     {
-        typedef typename RelationBuilder::template build
-        <
-            LeftData,
-            RightData
+        typedef BOOST_DEDUCED_TYPENAME RelationBuilder
+        ::BOOST_NESTED_TEMPLATE build<LeftData,RightData>::type rel_type;
 
-        >::type rel_type;
+        rel_type rel(lv, rv);
 
-        rel_type rel( lv, rv );
-
-        test_relation_with_default_tags( rel, lv, rv);
+        test_relation_with_default_tags(rel, lv, rv);
     }
 
     // Tagged test
     {
-        typedef typename RelationBuilder::template build
-        <
-            tagged<LeftData , left_user_tag  >,
-            tagged<RightData, right_user_tag >
-
+        typedef BOOST_DEDUCED_TYPENAME RelationBuilder
+        ::BOOST_NESTED_TEMPLATE build<
+            tagged<LeftData,left_user_tag>
+          , tagged<RightData,right_user_tag>
         >::type rel_type;
 
-        rel_type rel( lv, rv );
+        rel_type rel(lv, rv);
 
-        test_relation_with_default_tags(rel, lv, rv );
-        test_relation_with_user_tags
-        <
-            rel_type,
-            left_user_tag,right_user_tag
-
-        >(rel,lv,rv);
+        test_relation_with_default_tags(rel, lv, rv);
+        test_relation_with_user_tags<
+            rel_type
+          , left_user_tag
+          , right_user_tag
+        >(rel, lv, rv);
     }
 
     // Default Constructor, Constructor from views and some operators
     {
-/*
-        typedef typename RelationBuilder::template build
-        <
-            tagged<LeftData , left_user_tag  >,
-            tagged<RightData, right_user_tag >
-
+#if 0
+        typedef BOOST_DEDUCED_TYPENAME RelationBuilder
+        ::BOOST_NESTED_TEMPLATE build<
+            tagged<LeftData,left_user_tag>
+          , tagged<RightData,right_user_tag>
         >::type rel_type;
+        typedef BOOST_DEDUCED_TYPENAME pair_type_by<
+            left_user_tag
+          , rel_type
+        >::type left_pair;
+        typedef BOOST_DEDUCED_TYPENAME pair_type_by<
+            right_user_tag
+          , rel_type
+        >::type right_pair;
 
-        typedef typename pair_type_by< left_user_tag,rel_type>::type  left_pair;
-        typedef typename pair_type_by<right_user_tag,rel_type>::type right_pair;
+        rel_type rel_from_left(left_pair(lv, rv));
+        rel_type rel_from_right(right_pair(rv, lv));
 
-        rel_type rel_from_left (  left_pair(lv,rv) );
-        rel_type rel_from_right( right_pair(rv,lv) );
-
-        BOOST_CHECK( rel_from_left == rel_from_right  );
-        BOOST_CHECK( rel_from_left == rel_type(lv,rv) );
+        BOOST_TEST(rel_from_left == rel_from_right);
+        BOOST_TEST(rel_from_left == rel_type(lv, rv));
 
         rel_type rel;
 
         rel = rel_from_left;
 
-        BOOST_CHECK( rel == rel_from_left );
-*/
+        BOOST_TEST(rel == rel_from_left);
+#endif
     }
-
 }
 
 #endif // BOOST_BIMAP_TEST_TEST_RELATION_HPP
+

--- a/test/test_structured_pair.cpp
+++ b/test/test_structured_pair.cpp
@@ -17,83 +17,61 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
 
 // std
 #include <utility>
 #include <cstddef>
 
-// Boost.Static_assert
-#include <boost/static_assert.hpp>
-
 // Boost.Bimap
 #include <boost/bimap/detail/test/check_metadata.hpp>
-
 #include <boost/bimap/relation/structured_pair.hpp>
 
-
-BOOST_BIMAP_TEST_STATIC_FUNCTION( static_metadata_test )
+BOOST_BIMAP_TEST_STATIC_FUNCTION(static_metadata_test)
 {
     using namespace boost::bimaps::relation;
 
-    struct data_a { char     data; };
-    struct data_b { double   data; };
+    struct data_a { char data; };
+    struct data_b { double data; };
 
-    typedef structured_pair
-    <
-        data_a,
-        data_b,
-        normal_layout
+    typedef structured_pair<data_a,data_b,normal_layout> sp_ab;
+    typedef structured_pair<data_b,data_a,mirror_layout> sp_ba;
 
-    > sp_ab;
-
-    typedef structured_pair
-    <
-        data_b,
-        data_a,
-        mirror_layout
-
-    > sp_ba;
-
-    BOOST_BIMAP_CHECK_METADATA(sp_ab, first_type , data_a);
+    BOOST_BIMAP_CHECK_METADATA(sp_ab, first_type, data_a);
     BOOST_BIMAP_CHECK_METADATA(sp_ab, second_type, data_b);
 
-    BOOST_BIMAP_CHECK_METADATA(sp_ba, first_type , data_b);
+    BOOST_BIMAP_CHECK_METADATA(sp_ba, first_type, data_b);
     BOOST_BIMAP_CHECK_METADATA(sp_ba, second_type, data_a);
-
 }
-
 
 void test_basic()
 {
-
     using namespace boost::bimaps::relation;
 
-    // Instanciate two pairs and test the storage alignmentDataData
+    // Instantiate two pairs and test the storage alignmentDataData
 
-    typedef structured_pair< short, double, normal_layout > pair_type;
-    typedef structured_pair< double, short, mirror_layout > mirror_type;
+    typedef structured_pair<short,double,normal_layout> pair_type;
+    typedef structured_pair<double,short,mirror_layout> mirror_type;
 
-    pair_type   pa( 2, 3.1416 );
-    mirror_type pb( 3.1416, 2 );
+    pair_type pa(2, 3.1416);
+    mirror_type pb(3.1416, 2);
 
-    BOOST_CHECK( pa.first  == pb.second );
-    BOOST_CHECK( pa.second == pb.first  );
-    BOOST_CHECK( pair_type() < pa );
-    BOOST_CHECK( mirror_type() < pb );
+    BOOST_TEST(pa.first == pb.second);
+    BOOST_TEST(pa.second == pb.first);
+    BOOST_TEST(pair_type() < pa);
+    BOOST_TEST(mirror_type() < pb);
 }
 
-
-int test_main( int, char* [] )
+int main(int, char*[])
 {
-
-    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION( static_are_storage_compatible_test );
-
-    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION( static_metadata_test );
-
+    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION(
+        static_are_storage_compatible_test
+    );
+    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION(
+        static_metadata_test
+    );
     test_basic();
-
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/test_structured_pair.cpp
+++ b/test/test_structured_pair.cpp
@@ -80,7 +80,8 @@ void test_basic()
 
     BOOST_CHECK( pa.first  == pb.second );
     BOOST_CHECK( pa.second == pb.first  );
-
+    BOOST_CHECK( pair_type() < pa );
+    BOOST_CHECK( mirror_type() < pb );
 }
 
 

--- a/test/test_tagged.cpp
+++ b/test/test_tagged.cpp
@@ -17,10 +17,9 @@
 
 #include <boost/config.hpp>
 
-// Boost.Test
-#include <boost/test/minimal.hpp>
-
-#include <boost/static_assert.hpp>
+// Boost.Core.LightweightTest
+#include <boost/core/lightweight_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
 
 // Boost.MPL
 #include <boost/type_traits/is_same.hpp>
@@ -40,69 +39,64 @@
 #include <boost/bimap/tags/support/value_type_of.hpp>
 #include <boost/bimap/tags/support/apply_to_value_type.hpp>
 
-
-
-
-BOOST_BIMAP_TEST_STATIC_FUNCTION( test_metafunctions )
+BOOST_BIMAP_TEST_STATIC_FUNCTION(test_metafunctions)
 {
     using namespace boost::bimaps::tags::support;
     using namespace boost::bimaps::tags;
     using namespace boost::mpl::placeholders;
     using namespace boost;
 
-    struct tag      {};
-    struct value    {};
+    struct tag {};
+    struct value {};
 
     // Test apply_to_value_type metafunction
     // tagged<value,tag> ----(add_const<_>)----> tagged<value const,tag>
-    typedef tagged< value, tag > ttype;
-    typedef apply_to_value_type< add_const<_>,ttype>::type result;
+    typedef tagged<value,tag> ttype;
+    typedef apply_to_value_type<add_const<_>,ttype>::type result;
     typedef is_same<tagged<value const,tag>,result> compare;
     BOOST_MPL_ASSERT_MSG(compare::value,tag,(result));
 }
 
 struct tag_a {};
 struct tag_b {};
-struct data  {};
+struct data {};
 
 void test_function()
 {
-
     using namespace boost::bimaps::tags::support;
     using namespace boost::bimaps::tags;
     using boost::is_same;
 
-    typedef tagged< data, tag_a > data_a;
-    typedef tagged< data, tag_b > data_b;
+    typedef tagged<data,tag_a> data_a;
+    typedef tagged<data,tag_b> data_b;
 
-    BOOST_CHECK(( is_same< data_a::value_type   , data  >::value ));
-    BOOST_CHECK(( is_same< data_a::tag          , tag_a >::value ));
+    BOOST_TEST_TRAIT_TRUE((is_same<data_a::value_type,data>));
+    BOOST_TEST_TRAIT_TRUE((is_same<data_a::tag,tag_a>));
 
-    BOOST_CHECK((
-        is_same< overwrite_tagged < data_a, tag_b >::type, data_b >::value
+    BOOST_TEST_TRAIT_TRUE((
+        is_same< overwrite_tagged<data_a,tag_b>::type,data_b>
     ));
-    BOOST_CHECK((
-        is_same< default_tagged   < data_a, tag_b >::type, data_a >::value
+    BOOST_TEST_TRAIT_TRUE((
+        is_same< default_tagged<data_a,tag_b>::type,data_a>
     ));
-    BOOST_CHECK(( 
-        is_same< default_tagged   < data  , tag_b >::type, data_b >::value
+    BOOST_TEST_TRAIT_TRUE(( 
+        is_same< default_tagged<data,tag_b>::type,data_b>
     ));
 
-    BOOST_CHECK(( is_tagged< data   >::value == false ));
-    BOOST_CHECK(( is_tagged< data_a >::value == true  ));
+    BOOST_TEST_TRAIT_FALSE((is_tagged<data>));
+    BOOST_TEST_TRAIT_TRUE((is_tagged<data_a>));
 
-    BOOST_CHECK(( is_same< value_type_of<data_a>::type, data  >::value ));
-    BOOST_CHECK(( is_same< tag_of       <data_a>::type, tag_a >::value ));
-
+    BOOST_TEST_TRAIT_TRUE((is_same<value_type_of<data_a>::type,data>));
+    BOOST_TEST_TRAIT_TRUE((is_same<tag_of<data_a>::type,tag_a>));
 }
 
-int test_main( int, char* [] )
+int main(int, char*[])
 {
     test_function();
 
     // Test metanfunctions
-    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION( test_metafunctions );
+    BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION(test_metafunctions);
 
-    return 0;
+    return boost::report_errors();
 }
 


### PR DESCRIPTION
1. An AppVeyor YAML script is now functional.  The existing Travis YAML script has been upgraded.  Test programs use Boost.Core.LightweightTest vice Boost.Test.
2. The unordered_associative_container_adaptor base class now implements member functions hash_function(), key_eq(), and reserve().
3. The structured_pair test program now includes tests for the comparison operators.