### PR TITLE
Fix structured_pair default ctors; update structured_pair test

### DIFF
--- a/include/boost/bimap/relation/structured_pair.hpp
+++ b/include/boost/bimap/relation/structured_pair.hpp
@@ -67,7 +67,7 @@ class normal_storage :
     first_type   first;
     second_type  second;
 
-    normal_storage() {}
+    normal_storage() : first(), second() {}
 
     normal_storage(BOOST_DEDUCED_TYPENAME ::boost::call_traits<
                         first_type >::param_type f,
@@ -104,7 +104,7 @@ class mirror_storage :
     second_type  second;
     first_type   first;
 
-    mirror_storage() {}
+    mirror_storage() : second(), first() {}
 
     mirror_storage(BOOST_DEDUCED_TYPENAME ::boost::call_traits<first_type  >::param_type f,
                    BOOST_DEDUCED_TYPENAME ::boost::call_traits<second_type >::param_type s)
@@ -118,7 +118,7 @@ class mirror_storage :
 };
 
 /** \struct boost::bimaps::relation::storage_finder
-\brief Obtain the a storage with the correct layout.
+\brief Obtain the storage with the correct layout.
 
 \code
 template< class FirstType, class SecondType, class Layout >
@@ -174,7 +174,7 @@ class pair_info_hook :
 
     protected:
 
-    pair_info_hook() {}
+    pair_info_hook() : base_(), info() {}
 
     pair_info_hook( BOOST_DEDUCED_TYPENAME ::boost::call_traits<
                         BOOST_DEDUCED_TYPENAME base_::first_type
@@ -218,7 +218,7 @@ class pair_info_hook<TA,TB,::boost::mpl::na,Layout> :
 
     protected:
 
-    pair_info_hook() {}
+    pair_info_hook() : base_() {}
 
     pair_info_hook( BOOST_DEDUCED_TYPENAME ::boost::call_traits<
                         BOOST_DEDUCED_TYPENAME base_::first_type
@@ -254,7 +254,7 @@ class mutant_relation;
 /// \brief A std::pair signature compatible class that allows you to control
 ///        the internal structure of the data.
 /**
-This class allows you to specify the order in wich the two data types will be
+This class allows you to specify the order in which the two data types will be
 in the layout of the class.
                                                                                **/
 
@@ -291,7 +291,7 @@ class structured_pair :
 
     > mutant_views;
 
-    structured_pair() {}
+    structured_pair() : base_(){}
 
     structured_pair(BOOST_DEDUCED_TYPENAME boost::call_traits<
                         BOOST_DEDUCED_TYPENAME base_::first_type  >::param_type f,

--- a/test/test_structured_pair.cpp
+++ b/test/test_structured_pair.cpp
@@ -70,7 +70,7 @@ void test_basic()
 
     using namespace boost::bimaps::relation;
 
-    // Instanciate two pairs and test the storage alignmentDataData
+    // Instantiate two pairs and test the storage alignmentDataData
 
     typedef structured_pair< short, double, normal_layout > pair_type;
     typedef structured_pair< double, short, mirror_layout > mirror_type;
@@ -80,7 +80,8 @@ void test_basic()
 
     BOOST_CHECK( pa.first  == pb.second );
     BOOST_CHECK( pa.second == pb.first  );
-
+    BOOST_CHECK( pair_type()   < pa     );
+    BOOST_CHECK( mirror_type() < pb     );
 }
 
 


### PR DESCRIPTION
- structured_pair.hpp: Default constructors now invoke member default constructors explicitly.
- test_structured_pair.cpp: Added tests for structured_pair less-than operator.