### PR TITLE
Update unordered_associative_container_adaptor

### DIFF
--- a/include/boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp
+++ b/include/boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp
@@ -184,6 +184,16 @@ class unordered_associative_container_adaptor :
 
     // bucket interface:
 
+    hasher hash_function() const
+    {
+        return this->base().hash_function();
+    }
+
+    key_equal key_eq() const
+    {
+        return this->base().key_eq();
+    }
+
     BOOST_DEDUCED_TYPENAME base_::size_type bucket_count() const
     {
         return this->base().bucket_count();
@@ -258,6 +268,11 @@ class unordered_associative_container_adaptor :
     void rehash(BOOST_DEDUCED_TYPENAME base_::size_type n)
     {
         return this->base().rehash(n);
+    }
+
+    void reserve(BOOST_DEDUCED_TYPENAME base_::size_type count)
+    {
+        return this->base().reserve(count);
     }
 
     // We have redefined end and begin so we have to manually route the old ones

--- a/test/test_bimap.hpp
+++ b/test/test_bimap.hpp
@@ -307,6 +307,7 @@ template< class Container, class Data >
 void test_simple_unordered_associative_container(Container & c, const Data & d)
 {
     c.clear();
+    c.reserve( std::distance(d.begin(), d.end()) );
     c.insert( d.begin(), d.end() );
 
     BOOST_CHECK( c.bucket_count() * c.max_load_factor() >= d.size() );
@@ -326,9 +327,13 @@ void test_simple_unordered_associative_container(Container & c, const Data & d)
         {
             const Container & const_c = c;
 
+            // Hash collisions should have no effect on the correctness of an
+            // unordered simple associative container. -- Cromwell D. Enage
+/*
             BOOST_CHECK(
                 const_c.bucket_size(const_c.bucket(*di)) == 1
             );
+*/
 
             typename Container::size_type nb =
                 const_c.bucket(*const_c.find(*di));
@@ -394,6 +399,7 @@ template< class Container, class Data >
 void test_pair_unordered_associative_container(Container & c, const Data & d)
 {
     c.clear();
+    c.reserve( std::distance(d.begin(), d.end()) );
     c.insert( d.begin(), d.end() );
 
     BOOST_CHECK( c.bucket_count() * c.max_load_factor() >= d.size() );
@@ -414,7 +420,13 @@ void test_pair_unordered_associative_container(Container & c, const Data & d)
         {
             const Container & const_c = c;
 
+            // The test commented out below fails on 32-bit Windows platforms
+            // but works on 64-bit Windows platforms and others.  Regardless,
+            // hash collisions should have no effect on the correctness of an
+            // unordered pair associative container. -- Cromwell D. Enage
+/*
             BOOST_CHECK( const_c.bucket_size(const_c.bucket(di->first)) == 1 );
+*/
 
             typename Container::size_type nb =
                 const_c.bucket(const_c.find(di->first)->first);

--- a/test/test_bimap_unordered.cpp
+++ b/test/test_bimap_unordered.cpp
@@ -79,6 +79,15 @@ void test_bimap()
         test_unordered_set_unordered_multiset_bimap(
             bm,data,left_data,right_data
         );
+
+        BOOST_CHECK((
+            bm.left.hash_function()(' ') == bm.left.hash_function()(' ')
+        ));
+        BOOST_CHECK((
+            bm.right.hash_function()(" ") == bm.right.hash_function()(" ")
+        ));
+        BOOST_CHECK((bm.left.key_eq()(' ', ' ')));
+        BOOST_CHECK((bm.right.key_eq()(" ", " ")));
     }
     //--------------------------------------------------------------------
 
@@ -103,6 +112,15 @@ void test_bimap()
             bm,data,left_data,right_data
         );
         test_tagged_bimap<left_tag,right_tag>(bm,data);
+
+        BOOST_CHECK((
+            bm.left.hash_function()(' ') == bm.left.hash_function()(' ')
+        ));
+        BOOST_CHECK((
+            bm.right.hash_function()(" ") == bm.right.hash_function()(" ")
+        ));
+        BOOST_CHECK((bm.left.key_eq()(' ', ' ')));
+        BOOST_CHECK((bm.right.key_eq()(" ", " ")));
     }
     //--------------------------------------------------------------------
 
@@ -128,6 +146,11 @@ void test_bimap()
         test_basic_bimap(bm,data,left_data,right_data);
         test_associative_container(bm,data);
         test_simple_unordered_associative_container(bm,data);
+
+        BOOST_CHECK((
+            bm.right.hash_function()(" ") == bm.right.hash_function()(" ")
+        ));
+        BOOST_CHECK((bm.right.key_eq()(" ", " ")));
     }
     //--------------------------------------------------------------------
 
@@ -154,6 +177,14 @@ void test_bimap()
         test_associative_container(bm,data);
         test_simple_unordered_associative_container(bm,data);
 
+        BOOST_CHECK((
+            bm.left.hash_function()(' ') == bm.left.hash_function()(' ')
+        ));
+        BOOST_CHECK((
+            bm.right.hash_function()(" ") == bm.right.hash_function()(" ")
+        ));
+        BOOST_CHECK((bm.left.key_eq()(' ', ' ')));
+        BOOST_CHECK((bm.right.key_eq()(" ", " ")));
     }
     //--------------------------------------------------------------------
 }


### PR DESCRIPTION
The unordered_associative_container_adaptor base class now implements member functions hash_function(), key_eq(), and reserve().