### PR TITLE
removed deprecated std::allocator<void>

### DIFF
--- a/include/boost/bimap/detail/bimap_core.hpp
+++ b/include/boost/bimap/detail/bimap_core.hpp
@@ -18,7 +18,9 @@
 
 #include <boost/config.hpp>
 
+#ifndef BOOST_NO_CXX11_ALLOCATOR
 #include <memory>
+#endif
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/push_front.hpp>
 #include <boost/mpl/if.hpp>

--- a/include/boost/bimap/detail/bimap_core.hpp
+++ b/include/boost/bimap/detail/bimap_core.hpp
@@ -404,9 +404,13 @@ class bimap_core
     <
         relation,
         core_indices,
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         BOOST_DEDUCED_TYPENAME parameters::allocator::
             BOOST_NESTED_TEMPLATE rebind<relation>::other
-
+#else
+		BOOST_DEDUCED_TYPENAME std::allocator_traits< BOOST_DEDUCED_TYPENAME parameters::allocator >::
+			BOOST_NESTED_TEMPLATE rebind_alloc<relation>
+#endif
     > core_type;
 
     // Core metadata

--- a/include/boost/bimap/detail/bimap_core.hpp
+++ b/include/boost/bimap/detail/bimap_core.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/config.hpp>
 
+#include <memory>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/push_front.hpp>
 #include <boost/mpl/if.hpp>

--- a/include/boost/bimap/detail/manage_additional_parameters.hpp
+++ b/include/boost/bimap/detail/manage_additional_parameters.hpp
@@ -83,7 +83,7 @@ struct manage_additional_parameters
     struct case_NNN
     {
         typedef left_based set_type_of_relation;
-        typedef std::allocator<void> allocator;
+        typedef std::allocator<char> allocator;
         typedef ::boost::mpl::na additional_info;
     };
 
@@ -110,7 +110,7 @@ struct manage_additional_parameters
     struct case_SNN
     {
         typedef AP1 set_type_of_relation;
-        typedef std::allocator<void> allocator;
+        typedef std::allocator<char> allocator;
         typedef ::boost::mpl::na additional_info;
     };
 
@@ -137,7 +137,7 @@ struct manage_additional_parameters
     struct case_HNN
     {
         typedef left_based set_type_of_relation;
-        typedef std::allocator<void> allocator;
+        typedef std::allocator<char> allocator;
         typedef BOOST_DEDUCED_TYPENAME AP1::value_type additional_info;
     };
 
@@ -151,7 +151,7 @@ struct manage_additional_parameters
     struct case_SHN
     {
         typedef AP1 set_type_of_relation;
-        typedef std::allocator<void> allocator;
+        typedef std::allocator<char> allocator;
         typedef BOOST_DEDUCED_TYPENAME AP2::value_type additional_info;
     };
 


### PR DESCRIPTION
replaced std::allocator<void> by std::allocator<char>
use std::allocator_traits for rebinding

usage of std::allocator_traits is guarded by BOOST_NO_CXX11_ALLOCATOR macro