### PR TITLE
Add `std::initializer_list` constructor

### DIFF
--- a/include/boost/bimap/bimap.hpp
+++ b/include/boost/bimap/bimap.hpp
@@ -265,6 +265,29 @@ class bimap
 
    {}
 
+   #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+   bimap(std::initializer_list<BOOST_DEDUCED_TYPENAME base_::core_type::value_type> init,
+         const allocator_type& al = allocator_type()) :
+
+       base_::relation_set(
+           ::boost::multi_index::get<
+               BOOST_DEDUCED_TYPENAME base_::logic_relation_set_tag>(core)
+       ),
+
+       core(init,ctor_args_list(),al),
+
+       left (
+           ::boost::multi_index::get<
+               BOOST_DEDUCED_TYPENAME base_::logic_left_tag>(core)
+       ),
+       right (
+           ::boost::multi_index::get<
+               BOOST_DEDUCED_TYPENAME base_::logic_right_tag>(core)
+       )
+
+   {}
+   #endif
+
    bimap(const bimap& x) :
 
        base_::relation_set(


### PR DESCRIPTION
C++11 allows list initialization for classes. STL map has been [added a constructor](https://isocpp.org/wiki/faq/cpp11-language#init-list) with the signature

```c++
map(initializer_list<value_type> il,
    const allocator_type& alloc = allocator_type());
```

Added a similar constructor to bimap, allowing for initialization in the form of initializer list, such as

```c++
boost::bimap<double, long> tdn {
    {114.514, 1919},
    {891.931, 810}
};
```