### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/bimap
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,28 +5,31 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/concept_check//boost_concept_check
+    /boost/config//boost_config
+    /boost/container_hash//boost_container_hash
+    /boost/core//boost_core
+    /boost/iterator//boost_iterator
+    /boost/lambda//boost_lambda
+    /boost/mpl//boost_mpl
+    /boost/multi_index//boost_multi_index
+    /boost/preprocessor//boost_preprocessor
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/bimap
     : common-requirements
         <include>include
-        <library>/boost/concept_check//boost_concept_check
-        <library>/boost/config//boost_config
-        <library>/boost/container_hash//boost_container_hash
-        <library>/boost/core//boost_core
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/lambda//boost_lambda
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/multi_index//boost_multi_index
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
     ;
 
 explicit
-    [ alias boost_bimap ]
+    [ alias boost_bimap : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_bimap example test ]
     ;
 
 call-if : boost-library bimap
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/bimap

--- a/build.jam
+++ b/build.jam
@@ -8,19 +8,19 @@ import project ;
 project /boost/bimap
     : common-requirements
         <include>include
-        <source>/boost/concept_check//boost_concept_check
-        <source>/boost/config//boost_config
-        <source>/boost/container_hash//boost_container_hash
-        <source>/boost/core//boost_core
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/lambda//boost_lambda
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/multi_index//boost_multi_index
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/concept_check//boost_concept_check
+        <library>/boost/config//boost_config
+        <library>/boost/container_hash//boost_container_hash
+        <library>/boost/core//boost_core
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/lambda//boost_lambda
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/multi_index//boost_multi_index
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
     ;
 
 explicit

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,32 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/bimap
+    : common-requirements
+        <include>include
+        <source>/boost/concept_check//boost_concept_check
+        <source>/boost/config//boost_config
+        <source>/boost/container_hash//boost_container_hash
+        <source>/boost/core//boost_core
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/lambda//boost_lambda
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/multi_index//boost_multi_index
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+    ;
+
+explicit
+    [ alias boost_bimap ]
+    [ alias all : boost_bimap example test ]
+    ;
+
+call-if : boost-library bimap
+    ;

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -9,6 +9,8 @@
 # bring in rules for testing
 import testing ;
 
+project : requirements <library>/boost/bimap/boost_bimap ;
+
 test-suite "examples"
     :
     [ compile mighty_bimap.cpp                                        ]

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -9,7 +9,7 @@
 # bring in rules for testing
 import testing ;
 
-project : requirements <library>/boost/bimap/boost_bimap ;
+project : requirements <library>/boost/bimap//boost_bimap ;
 
 test-suite "examples"
     :

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -15,8 +15,11 @@ test-suite "examples"
     [ run     simple_bimap.cpp                                        ]
     [ run     tagged_simple_bimap.cpp                                 ]
     [ run     step_by_step.cpp                                        ]
-    [ run     population_bimap.cpp                                    ]
-    [ run     repetitions_counter.cpp                                 ]
+    [ run     population_bimap.cpp
+                    /boost/assign//boost_assign
+                    /boost/foreach//boost_foreach                     ]
+    [ run     repetitions_counter.cpp
+                    /boost/tokenizer//boost_tokenizer                 ]
     [ compile user_defined_names.cpp                                  ]
     [ run     standard_map_comparison.cpp                             ]
     [ run     at_function_examples.cpp                                ]
@@ -30,11 +33,15 @@ test-suite "examples"
 test-suite "bimap_and_boost"
     :
     [ run     bimap_and_boost/property_map.cpp                        ]
-    [ run     bimap_and_boost/range.cpp                               ]
-    [ run     bimap_and_boost/foreach.cpp                             ]
+    [ run     bimap_and_boost/range.cpp
+                    /boost/range//boost_range                         ]
+    [ run     bimap_and_boost/foreach.cpp
+                    /boost/foreach//boost_foreach                     ]
     [ run     bimap_and_boost/lambda.cpp                              ]
-    [ run     bimap_and_boost/assign.cpp                              ]
-    [ run     bimap_and_boost/xpressive.cpp                           ]
+    [ run     bimap_and_boost/assign.cpp
+                    /boost/assign//boost_assign                       ]
+    [ run     bimap_and_boost/xpressive.cpp
+                    /boost/xpressive//boost_xpressive                 ]
     [ run     bimap_and_boost/typeof.cpp                              ]
     [ run     bimap_and_boost/serialization.cpp
                     /boost/serialization//boost_serialization         ]
@@ -42,9 +49,13 @@ test-suite "bimap_and_boost"
 
 test-suite "mi_to_b_path"
     :
-    [ compile mi_to_b_path/bidirectional_map.cpp                      ]
-    [ run     mi_to_b_path/hashed_indices.cpp                         ]
+    [ compile mi_to_b_path/bidirectional_map.cpp
+                    /boost/tokenizer//boost_tokenizer                 ]
+    [ run     mi_to_b_path/hashed_indices.cpp
+                    /boost/tokenizer//boost_tokenizer                 ]
     [ compile mi_to_b_path/tagged_bidirectional_map.cpp               ]
-    [ compile mi_to_b_path/mi_bidirectional_map.cpp                   ]
-    [ run     mi_to_b_path/mi_hashed_indices.cpp                      ]
+    [ compile mi_to_b_path/mi_bidirectional_map.cpp
+                    /boost/tokenizer//boost_tokenizer                 ]
+    [ run     mi_to_b_path/mi_hashed_indices.cpp
+                    /boost/tokenizer//boost_tokenizer                 ]
     ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -11,6 +11,7 @@ import testing ;
 
 project : requirements
     <include>.
+    <library>/boost/bimap/boost_bimap
     ;
 
 test-suite "tagged_test"

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -11,7 +11,7 @@ import testing ;
 
 project : requirements
     <include>.
-    <library>/boost/bimap/boost_bimap
+    <library>/boost/bimap//boost_bimap
     ;
 
 test-suite "tagged_test"

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,6 +9,9 @@
 # bring in rules for testing
 import testing ;
 
+project : requirements
+    <include>.
+    ;
 
 test-suite "tagged_test"
     :
@@ -41,10 +44,12 @@ test-suite "bimap_test"
     [ run test_bimap_sequenced.cpp : : :
           <toolset>gcc-4.4.7,<variant>release:<build>no                       ]
     [ run test_bimap_unconstrained.cpp                                        ]
-    [ run test_bimap_assign.cpp                                               ]
+    [ run test_bimap_assign.cpp
+          /boost/assign//boost_assign                                         ]
     [ run test_bimap_property_map.cpp                                         ]
     [ run test_bimap_modify.cpp                                               ]
-    [ run test_bimap_range.cpp                                                ]
+    [ run test_bimap_range.cpp
+          /boost/range//boost_range                                           ]
     [ run test_bimap_operator_bracket.cpp                                     ]
     [ run test_bimap_lambda.cpp                                               ]
     [ run test_bimap_mutable.cpp                                              ]
@@ -70,11 +75,16 @@ test-suite "compile_fail_test"
 test-suite "bimap_and_boost"
     :
     [ run     ../example/bimap_and_boost/property_map.cpp                     ]
-    [ run     ../example/bimap_and_boost/range.cpp                            ]
-    [ run     ../example/bimap_and_boost/foreach.cpp                          ]
+    [ run     ../example/bimap_and_boost/range.cpp
+                    /boost/range//boost_range                                 ]
+    [ run     ../example/bimap_and_boost/foreach.cpp
+                    /boost/foreach//boost_foreach                             ]
     [ run     ../example/bimap_and_boost/lambda.cpp                           ]
-    [ run     ../example/bimap_and_boost/assign.cpp                           ]
-    [ run     ../example/bimap_and_boost/xpressive.cpp : : :
+    [ run     ../example/bimap_and_boost/assign.cpp
+                    /boost/assign//boost_assign                               ]
+    [ run     ../example/bimap_and_boost/xpressive.cpp
+                    /boost/xpressive//boost_xpressive
+        : : :
         <toolset>gcc-10,<cxxstd>03:<build>no
         <toolset>gcc-11,<cxxstd>03:<build>no                                  ]
     [ run     ../example/bimap_and_boost/typeof.cpp                           ]

--- a/test/test_bimap_info.cpp
+++ b/test/test_bimap_info.cpp
@@ -27,7 +27,7 @@
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/unordered_set_of.hpp>
 
-#include <libs/bimap/test/strong_type.hpp>
+#include <strong_type.hpp>
 
 int test_bimap_info()
 {
@@ -123,13 +123,13 @@ void test_heterogeneous_access_bimap_info()
     using namespace boost::bimaps;
 
     typedef bimap
-    < 
+    <
       set_of< int, std::less< strong<int> > >,
       unordered_set_of
       <
         int, boost::hash< strong<int> >, std::equal_to< strong<int> >
       >,
-      with_info<int> 
+      with_info<int>
     > bm_type;
 
     bm_type bm;

--- a/test/test_bimap_operator_bracket.cpp
+++ b/test/test_bimap_operator_bracket.cpp
@@ -29,7 +29,7 @@
 #include <boost/bimap/vector_of.hpp>
 #include <boost/bimap/unconstrained_set_of.hpp>
 
-#include <libs/bimap/test/strong_type.hpp>
+#include <strong_type.hpp>
 
 void test_bimap_operator_bracket()
 {
@@ -194,7 +194,7 @@ void test_bimap_operator_bracket()
         typedef bimap
         <
           set_of<int, std::less< strong<int> > >,
-          list_of<std::string>                    
+          list_of<std::string>
         > bm;
 
         bm b;

--- a/test/test_bimap_ordered.cpp
+++ b/test/test_bimap_ordered.cpp
@@ -34,7 +34,7 @@
 // bimap container
 #include <boost/bimap/bimap.hpp>
 
-#include <libs/bimap/test/test_bimap.hpp>
+#include <test_bimap.hpp>
 
 struct  left_tag {};
 struct right_tag {};

--- a/test/test_bimap_sequenced.cpp
+++ b/test/test_bimap_sequenced.cpp
@@ -37,7 +37,7 @@
 #include <boost/bimap/bimap.hpp>
 #include <boost/bimap/support/lambda.hpp>
 
-#include <libs/bimap/test/test_bimap.hpp>
+#include <test_bimap.hpp>
 
 struct  left_tag {};
 struct right_tag {};

--- a/test/test_bimap_unordered.cpp
+++ b/test/test_bimap_unordered.cpp
@@ -34,7 +34,7 @@
 // bimap container
 #include <boost/bimap/bimap.hpp>
 
-#include <libs/bimap/test/test_bimap.hpp>
+#include <test_bimap.hpp>
 
 struct  left_tag {};
 struct right_tag {};


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.