### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(boost_bimap
     Boost::mpl
     Boost::multi_index
     Boost::preprocessor
-    Boost::static_assert
     Boost::throw_exception
     Boost::type_traits
     Boost::utility

--- a/build.jam
+++ b/build.jam
@@ -15,7 +15,6 @@ constant boost_dependencies :
     /boost/mpl//boost_mpl
     /boost/multi_index//boost_multi_index
     /boost/preprocessor//boost_preprocessor
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits
     /boost/utility//boost_utility ;


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.